### PR TITLE
GHCi: replaces IORefs with a single StablePtr.

### DIFF
--- a/H.ghci
+++ b/H.ghci
@@ -6,17 +6,13 @@ import qualified H.Prelude as H
 import Language.R.Runtime.QQ as QQ
 
 :{
-:def updateR
-     (\_ -> return
-        $ ":cmd (Data.IORef.writeIORef Language.R.globalEnv =<< Foreign.peek Foreign.R.globalEnv) "
-       ++ ">> (Data.IORef.writeIORef Language.R.globalEnv =<< Foreign.peek Foreign.R.globalEnv) "
-       ++ ">> (Data.IORef.writeIORef Language.R.nilValue =<< Foreign.peek Foreign.R.nilValue) "
-       ++ ">> (Data.IORef.writeIORef Language.R.unboundValue =<< Foreign.peek Foreign.R.unboundValue) "
-       ++ ">> (Data.IORef.writeIORef Language.R.baseEnv =<< Foreign.peek Foreign.R.baseEnv) "
-       ++ ">> (Foreign.poke Foreign.R.rInteractive 0) "
-       ++ ">> return \"\""
-     )
+Language.R.pokeRVariables
+    ( Foreign.R.globalEnv
+    , Foreign.R.baseEnv
+    , Foreign.R.nilValue
+    , Foreign.R.unboundValue
+    , Foreign.R.missingArg
+    , Foreign.R.rInteractive
+    )
 :}
-
 Language.R.Interpreter.initialize Language.R.Interpreter.defaultConfig
-:updateR

--- a/cbits/missing_r.c
+++ b/cbits/missing_r.c
@@ -1,8 +1,7 @@
 // Copyright: (C) 2013 Amgen, Inc.
-#include <R.h>
-
 #define USE_RINTERNALS
-#include <Rinternals.h>
+#include <missing_r.h>
+#include <R.h>
 
 SEXP * INNER_VECTOR(SEXP x) {
     return VECTOR_PTR(x);
@@ -35,5 +34,8 @@ static inline SEXP Rf_MakeNativeSymbolRef(DL_FUNC f)
 SEXP funPtrToSEXP(DL_FUNC pf) {
     return Rf_MakeNativeSymbolRef(pf);
 };
+
+int isRInitialized = 0;
+HsStablePtr rVariables;
 
 #undef USE_RINTERNALS

--- a/cbits/missing_r.h
+++ b/cbits/missing_r.h
@@ -2,10 +2,19 @@
 #ifndef MISSING_R__H
 #define MISSING_R__H
 
+#include "HsFFI.h"
+#include <Rinternals.h>
+
 SEXP * INNER_VECTOR(SEXP);
 
 #include <R_ext/Rdynload.h>
 
 SEXP funPtrToSEXP(DL_FUNC pf);
+
+// Indicates whether R has been initialized.
+extern int isRInitialized;
+
+// R global variables for GHCi.
+extern HsStablePtr rVariables;
 
 #endif

--- a/src/H/HExp.chs
+++ b/src/H/HExp.chs
@@ -31,7 +31,6 @@ import           Data.ByteString (ByteString)
 import Control.Applicative
 import Data.Int (Int32)
 import Data.Word (Word8)
-import Data.IORef ( readIORef )
 import Data.Complex
 import GHC.Ptr (Ptr(..))
 import Foreign.Storable
@@ -215,7 +214,7 @@ peekHExp s = do
 
 pokeHExp :: Ptr (HExp a) -> HExp a -> IO ()
 pokeHExp s h = do
-    nil <- readIORef LR.nilValue
+    nil <- peek LR.nilValuePtr
     let s' = castPtr s
     case h of
          Nil -> return ()
@@ -304,7 +303,7 @@ unhexp = unsafePerformIO . unhexpIO
 maybeNil :: SEXP a
          -> IO (Maybe (SEXP a))
 maybeNil s = do
-  nil <- readIORef LR.nilValue
+  nil <- peek LR.nilValuePtr
   return $
     if R.unsexp s == R.unsexp nil
       then Nothing

--- a/src/H/Prelude/Globals.hs
+++ b/src/H/Prelude/Globals.hs
@@ -11,19 +11,19 @@ module H.Prelude.Globals
   , missingArg
   ) where
 
+import Foreign ( peek )
 import Foreign.R  (SEXP, SEXPTYPE(..))
 import qualified Language.R as R
-import Data.IORef ( readIORef )
 import System.IO.Unsafe ( unsafePerformIO )
 
 unboundValue :: SEXP Symbol
-unboundValue = unsafePerformIO $ readIORef R.unboundValue
+unboundValue = unsafePerformIO $ peek R.unboundValuePtr
 
 globalEnv :: SEXP Env
-globalEnv = unsafePerformIO $ readIORef R.globalEnv
+globalEnv = unsafePerformIO $ peek R.globalEnvPtr
 
 nilValue :: SEXP Nil
-nilValue = unsafePerformIO $ readIORef R.nilValue
+nilValue = unsafePerformIO $ peek R.nilValuePtr
 
 missingArg :: SEXP Symbol
-missingArg = unsafePerformIO $ readIORef R.missingArg
+missingArg = unsafePerformIO $ peek R.missingArgPtr


### PR DESCRIPTION
Advantages:
- No need to update IORefs after reloading modules.
- Adding more variables requires less code.
- It is harder to forget to initialize a global variable.
