### PR TITLE
Fix RCStack problem on unix systems.

### DIFF
--- a/H.cabal
+++ b/H.cabal
@@ -75,6 +75,7 @@ library
     cpp-options:       -DH_ARCH_WINDOWS
     cc-options:        -DH_ARCH_WINDOWS
   else
+    build-depends:     unix >= 2.6
     pkgconfig-depends: libR >= 3.0
     cpp-options:       -DH_ARCH_UNIX
     cc-options:        -DH_ARCH_UNIX

--- a/src/Language/R/Interpreter.hs
+++ b/src/Language/R/Interpreter.hs
@@ -63,6 +63,10 @@ import System.Environment ( getProgName, lookupEnv )
 import System.IO.Unsafe   ( unsafePerformIO )
 import System.Process     ( readProcess )
 import System.SetEnv
+#ifdef H_ARCH_UNIX
+import System.Posix.Resource
+#endif
+
 
 -- | Configuration options for R runtime.
 data Config = Config
@@ -147,6 +151,9 @@ with cfg = bracket (initialize cfg) (const finalize) . const
 -- | Starts the R thread.
 startRThread :: ThreadId -> IO ()
 startRThread eventLoopThread = do
+#ifdef H_ARCH_UNIX
+    setResourceLimit ResourceStackSize (ResourceLimits ResourceLimitInfinity ResourceLimitInfinity)
+#endif
     chan <- newChan
     newStablePtr chan >>= poke interpreterChanPtr
     void $ forkOS $


### PR DESCRIPTION
R tries to check RStackLimit and make actions according to the
value read. Setting limit to unlimited fixes issues.
