### PR TITLE
Error cleanup.

### DIFF
--- a/src/Foreign/R/Error.chs
+++ b/src/Foreign/R/Error.chs
@@ -5,47 +5,16 @@
 {-# LANGUAGE DeriveDataTypeable #-}
 module Foreign.R.Error
   ( RError(..)
-  , failure
-  , violation
-  , impossible
-  , unimplemented
   ) where
 
 import Control.Exception
 import Data.Typeable
 
-data RError
-      = RError String
-      | Violation String String
-      | Failure String String
+data RError = RError String
       deriving ( Typeable )
 
 instance Show RError where
   show (RError s)      = "R Runtime Error: " ++ s
-  show (Failure f m)   = "User error:" ++ f ++ ":" ++ m
-  show (Violation f m) = "Bug in " ++ f ++ ", please report: " ++ m
 
 instance Exception RError
 
--- | User error.
-failure :: String                                 -- ^ Function name
-        -> String                                 -- ^ Error message
-        -> a
-failure f msg = throw $ Failure f msg
-
--- | An internal invariant has been violated. That's a bug.
-violation :: String                               -- ^ Function name
-          -> String                               -- ^ Error message
-          -> a
-violation f msg = throw $ Violation f msg
-
--- | A violation that should have been made impossible by the type system was
--- not.
-impossible :: String                               -- ^ Function name
-           -> a
-impossible f = violation f "The impossible happened."
-
--- | Feature not yet implemented.
-unimplemented :: String
-              -> a
-unimplemented f = failure f "Unimplemented."

--- a/src/Foreign/R/Type.hsc
+++ b/src/Foreign/R/Type.hsc
@@ -18,7 +18,7 @@ module Foreign.R.Type where
 #include <Rinternals.h>
 
 import H.Constraints
-import Foreign.R.Error
+import H.Internal.Error
 
 import qualified Language.Haskell.TH.Syntax as Hs
 import qualified Language.Haskell.TH.Lib as Hs

--- a/src/H/Internal/Error.hs
+++ b/src/H/Internal/Error.hs
@@ -5,8 +5,48 @@
 -- internal to H, or whether they are due to a mistake by the user.
 --
 -- This module should only be imported by H modules and not reexported.
-
+{-# LANGUAGE DeriveDataTypeable #-}
 module H.Internal.Error
-  ( module Foreign.R.Error ) where
+  ( failure
+  , violation
+  , impossible
+  , unimplemented
+  ) where
 
-import Foreign.R.Error
+import Control.Exception
+import Data.Typeable
+
+data Violation = Violation String String deriving ( Typeable )
+data Failure = Failure String String deriving ( Typeable )
+
+instance Show Failure where
+  show (Failure f m)   = "User error:" ++ f ++ ":" ++ m
+
+instance Show Violation where
+  show (Violation f m) = "Bug in " ++ f ++ ", please report: " ++ m
+
+instance Exception Violation
+instance Exception Failure
+
+-- | User error.
+failure :: String                                 -- ^ Function name
+        -> String                                 -- ^ Error message
+        -> a
+failure f msg = throw $ Failure f msg
+
+-- | An internal invariant has been violated. That's a bug.
+violation :: String                               -- ^ Function name
+          -> String                               -- ^ Error message
+          -> a
+violation f msg = throw $ Violation f msg
+
+-- | A violation that should have been made impossible by the type system was
+-- not.
+impossible :: String                               -- ^ Function name
+           -> a
+impossible f = violation f "The impossible happened."
+
+-- | Feature not yet implemented.
+unimplemented :: String
+              -> a
+unimplemented f = failure f "Unimplemented."


### PR DESCRIPTION
1). Introduce hierarchy for each type of errors.
2). Move helper methods back to H/Internal/Error
