### PR TITLE
Fix test failure in qq.ghci.

### DIFF
--- a/tests/ghci/qq.ghci
+++ b/tests/ghci/qq.ghci
@@ -87,7 +87,7 @@ H.print =<< [r| base::`+`(10,10) |]
 _ <- [r| `+` <- base::`+` |]
 
 :{
-let hFib :: Foreign.R.SEXP R.Int -> R s (Foreign.R.SEXP R.Int)
+let hFib :: Foreign.R.SEXP Foreign.R.Int -> H.Prelude.R s (Foreign.R.SEXP Foreign.R.Int)
     hFib n@(H.fromSEXP -> (0 :: Int32)) = fmap (flip R.asTypeOf n) [r| as.integer(0) |]
     hFib n@(H.fromSEXP -> (1 :: Int32)) = fmap (flip R.asTypeOf n) [r| as.integer(1) |]
     hFib n                              = H.withProtected (return n) $ const $


### PR DESCRIPTION
GHCi seemed to be confused about whether R is a module or a type
constructor:

```
<interactive>:96:28:
    Failed to load interface for `R'
    Use -v to see a list of the files searched for.
```
