### PR TITLE
Turns off shootout tests of runtime QQ in windows.

### DIFF
--- a/H.cabal
+++ b/H.cabal
@@ -158,6 +158,10 @@ test-suite test-shootout-programs
   ghc-options:         -Wall -threaded -fno-full-laziness
   hs-source-dirs:      tests
   default-language:    Haskell2010
+  if os(windows)
+    cpp-options:       -DH_ARCH_WINDOWS
+  else
+    cpp-options:       -DH_ARCH_UNIX
 
 benchmark compile-qq-benchmarks
   main-is:             compile-qq-benchmarks.hs


### PR DESCRIPTION
spectralnorm is blocking in windows once every few runs. As we are not fixing this test immediately, I'm removing the test with conditional compilation.
