### PR TITLE
Fix compile time QQ.

### DIFF
--- a/src/Language/R/QQ.hs
+++ b/src/Language/R/QQ.hs
@@ -197,7 +197,8 @@ instance TH.Lift (SEXP a) where
     lift (hexp -> Lang (hexp -> Symbol pname _ Nothing) rands)
       | Char (Vector.toString -> name) <- hexp pname
       , isSplice name = do
-        let hvar = TH.varE $ TH.mkName $ spliceNameChop name
+        let nm = spliceNameChop name
+        hvar <- fmap (TH.varE . (maybe (TH.mkName nm) id)) (TH.lookupValueName nm)
         [| let call = unsafePerformIO (installIO ".Call")
                f    = H.mkSEXP $hvar
              in unhexp $ Lang call (Just (unhexp $ List f rands Nothing)) |]


### PR DESCRIPTION
This commit introduces another way to capture external variables
this way is safe even in case of name clashes, i.e.:

foo x = [| let f = g x in ... |] in case if g x = "f" for old
code compiled into an endless loop (and didn't typecheck).

New code allowes g x = "f".
