### PR TITLE
Remove R phantom type parameter.

### DIFF
--- a/doc/H-user.md
+++ b/doc/H-user.md
@@ -82,7 +82,7 @@ to splice the Haskell value.
     H> H.printQuote [r| x_hs + x_hs |]
     [1] 4
 
-    H> let f x = return (x + 1) :: R s Double
+    H> let f x = return (x + 1) :: R Double
     H> H.printQuote [r| f_hs(1) |]
     [1] 2
 
@@ -164,9 +164,9 @@ provided to initialize R and to run `R` computations in the `IO`
 monad.
 
 ```Haskell
-runR         :: Config -> (forall s. R s a) -> IO a
-io           :: IO a -> R s a
-unsafeRToIO  :: R s a -> IO a
+runR         :: Config -> R a -> IO a
+io           :: IO a -> R a
+unsafeRToIO  :: R a -> IO a
 ```
 
 The `IO` monad is used instead in GHCi, as it allows evaluating
@@ -182,7 +182,7 @@ computations to the R thread.
 Additionally, callback functions passed from Haskell to R are expected
 to produce computations in the `R` monad, as in the example shown in
 the previous section, where the type given to `f` is `Double ->
-R s Double`.
+R Double`.
 
 How to analyze R values in Haskell
 ==================================
@@ -484,7 +484,7 @@ import Foreign.R (SEXP, SEXPTYPE)
 import Language.R.Instance as R
 import Language.R.QQ
 
-hello :: String -> R s ()
+hello :: String -> R ()
 hello name = do
     [r| print(s_hs) |]
     return ()

--- a/examples/fib/Fib.hs
+++ b/examples/fib/Fib.hs
@@ -19,21 +19,21 @@ import           Language.R.QQ
 
 neg :: SEXP 'R.Logical
     -> SEXP 'R.Int
-    -> R s R.SomeSEXP -- (SEXP 'R.Int)
+    -> R R.SomeSEXP -- (SEXP 'R.Int)
 neg (fromSEXP -> R.True)  (fromSEXP -> n :: Int32) = [r| n_hs |]
 neg (fromSEXP -> R.False) (fromSEXP -> n :: Int32) = [r| -n_hs |]
 neg (fromSEXP -> R.NA)    (fromSEXP -> _ :: Int32) = [r| NA |]
 neg _ _ = error "Impossible happen."
 
-fib :: SEXP 'R.Int -> R s R.SomeSEXP -- (SEXP 'R.Int)
+fib :: SEXP 'R.Int -> R R.SomeSEXP -- (SEXP 'R.Int)
 fib (fromSEXP -> 1 :: Int32) = return $ R.SomeSEXP $ mkSEXP (1 :: Int32)
 fib (fromSEXP -> 2 :: Int32) = return $ R.SomeSEXP $ mkSEXP (1 :: Int32)
 fib (fromSEXP -> n :: Int32) = [r| fib_hs(as.integer(n_hs - 1)) + fib_hs(as.integer(n_hs - 2)) |]
 
-fact :: Int32 -> R s Int32
+fact :: Int32 -> R Int32
 fact 0 = return 1
 fact n = fmap (H.fromSEXP . R.cast R.Int) [r| as.integer(n_hs * fact_hs(as.integer(n_hs - 1))) |]
 
-factSexp :: SEXP 'R.Int -> R s (SEXP 'R.Int)
+factSexp :: SEXP 'R.Int -> R (SEXP 'R.Int)
 factSexp (fromSEXP -> 0 :: Int32) = return $ mkSEXP (1::Int32)
 factSexp (fromSEXP -> n :: Int32) = fmap (H.fromSEXP.R.cast R.Int) [r| as.integer(n_hs * fact_hs(as.integer(n_hs -1))) |]

--- a/examples/nls-2/system.hs
+++ b/examples/nls-2/system.hs
@@ -19,7 +19,7 @@ generate ix =
           return $ r * (1 + 0.01 * v)
   where x = fromIntegral ix
 
-generate_lifted :: [Int32] -> R s [Double]
+generate_lifted :: [Int32] -> R [Double]
 generate_lifted = io .  (mapM generate)
 
 analyse :: R.SEXP a -> IO ()

--- a/examples/nls/system.hs
+++ b/examples/nls/system.hs
@@ -3,7 +3,7 @@ import Data.Int
 import System.Random.MWC
 import System.Random.MWC.Distributions
 
-generate :: Int32 -> R s Double
+generate :: Int32 -> R Double
 generate x = io $ 
   withSystemRandom . asGenIO $ \gen -> 
     let r = dx*dx+2*dx
@@ -11,5 +11,5 @@ generate x = io $
           return $ r*(1+0.05*v)
   where dx = fromIntegral x
 
-generate_lifted :: [Int32] -> R s [Double]
+generate_lifted :: [Int32] -> R [Double]
 generate_lifted = mapM generate

--- a/src/Language/R/Instance.hs
+++ b/src/Language/R/Instance.hs
@@ -8,9 +8,6 @@
 --
 -- The 'R' monad defined here serves to give static guarantees that an instance
 -- is only ever used after it has been initialized and before it is finalized.
--- Doing otherwise should result in a type error. This is done in the same way
--- that the 'Control.Monad.ST' monad encapsulates side effects: by assigning
--- a rank-2 type to the only run function for the monad.
 --
 -- This module is intended to be imported qualified.
 
@@ -108,7 +105,7 @@ import System.Posix.Resource
 -- the R interpreter, much as the 'IO' monad sequences actions interacting with
 -- the real world. The 'R' monad embeds the 'IO' monad, so all 'IO' actions can
 -- be lifted to 'R' actions.
-newtype R s a = R { _unR :: IO a }
+newtype R a = R { _unR :: IO a }
 #if MIN_VERSION_exceptions(0,4,0)
   deriving (Monad, MonadIO, Functor, MonadCatch, MonadThrow, Applicative)
 #else
@@ -116,19 +113,19 @@ newtype R s a = R { _unR :: IO a }
 #endif
 
 
-instance MonadR (R s) where
+instance MonadR R where
   io m = R $ unsafeRunInRThread m
 
 -- | Initialize a new instance of R, execute actions that interact with the
 -- R instance and then finalize the instance.
-runR :: Config -> (forall s. R s a) -> IO a
+runR :: Config -> R a -> IO a
 runR config (R m) = bracket_ (initialize config) finalize m
 
 -- | Run an R action in the global R instance from the IO monad. This action is
--- unsafe in the sense that use of it bypasses any static guarantees provided by
--- the R monad, in particular that the R instance was indeed initialized and has
--- not yet been finalized. It is a backdoor that should not normally be used.
-unsafeRToIO :: R s a -> IO a
+-- unsafe in the sense that use of it doesn't make sure that an R instance was
+-- indeed initialized and has not yet been finalized. It is a backdoor that
+-- should not normally be used.
+unsafeRToIO :: R a -> IO a
 unsafeRToIO (R m) = m
 
 -- | Configuration options for R runtime.

--- a/src/Language/R/Internal/FunWrappers/TH.hs
+++ b/src/Language/R/Internal/FunWrappers/TH.hs
@@ -63,11 +63,10 @@ thWrapperLiterals n m = mapM thWrapperLiteral [n..m]
 -- @
 thWrapperLiteral :: Int -> DecQ
 thWrapperLiteral n = do
-    s <- newName "s"
     tyvars1 <- replicateM (n + 1) (newName "a")
     tyvars2 <- replicateM (n + 1) (newName "i")
     let mkTy []     = impossible "thWrapperLiteral"
-        mkTy [x]    = conT (mkName "R") `appT` varT s `appT` varT x
+        mkTy [x]    = conT (mkName "R") `appT` varT x
         mkTy (x:xs) = arrowT `appT` varT x `appT` mkTy xs
         ctx = cxt (zipWith f tyvars1 tyvars2)
           where

--- a/src/Language/R/Literal.hs
+++ b/src/Language/R/Literal.hs
@@ -140,16 +140,16 @@ instance Literal String R.String where
     mkSEXP x = unsafePerformIO $ R.mkString =<< newCString x
     fromSEXP  = unimplemented "Literal String fromSEXP"
 
-instance Literal a b => Literal (R s a) R.ExtPtr where
+instance Literal a b => Literal (R a) R.ExtPtr where
     mkSEXP   = funToSEXP wrap0
     fromSEXP = unimplemented "Literal (Ra a) fromSEXP"
 
-instance (Literal a a0, Literal b b0) => Literal (a -> R s b) R.ExtPtr where
+instance (Literal a a0, Literal b b0) => Literal (a -> R b) R.ExtPtr where
     mkSEXP   = funToSEXP wrap1
     fromSEXP = unimplemented "Literal (a -> R b) fromSEXP"
 
 instance (Literal a a0, Literal b b0, Literal c c0)
-         => Literal (a -> b -> R s c) R.ExtPtr where
+         => Literal (a -> b -> R c) R.ExtPtr where
     mkSEXP   = funToSEXP wrap2
     fromSEXP = unimplemented "Literal (a -> b -> IO c) fromSEXP"
 
@@ -157,7 +157,7 @@ instance (Literal a a0, Literal b b0, Literal c c0)
 class HFunWrap a b | a -> b where
     hFunWrap :: a -> b
 
-instance Literal a la => HFunWrap (R s a) (IO (SEXP la)) where
+instance Literal a la => HFunWrap (R a) (IO (SEXP la)) where
     hFunWrap a = fmap (mkSEXP $!) (unsafeRToIO a)
 
 instance (Literal a la, HFunWrap b wb)

--- a/tests/compile-qq-benchmarks.hs
+++ b/tests/compile-qq-benchmarks.hs
@@ -26,7 +26,7 @@ fib 0 = 0
 fib 1 = 1
 fib n = fib (n-1) + fib (n-2)
 
-hFib :: SEXP R.Int -> R s (SEXP R.Int)
+hFib :: SEXP R.Int -> R (SEXP R.Int)
 hFib n@(fromSEXP -> (0 :: Int32)) = fmap (flip R.asTypeOf n) [r| as.integer(0) |]
 hFib n@(fromSEXP -> (1 :: Int32)) = fmap (flip R.asTypeOf n) [r| as.integer(1) |]
 hFib n                            = H.withProtected (return n) $ const $

--- a/tests/ghci/qq.ghci
+++ b/tests/ghci/qq.ghci
@@ -31,8 +31,8 @@ H.print =<< [r| z(3) |]
 
 -- Should be [1] 1 2 3 4 5 6 7 8 9 10
 H.print =<< [r| y <- c(1:10) |]
-let foo1 = (\x -> (return $ x+1 :: R s Double))
-let foo2 = (\x -> (return $ map (+1) x :: R s [Int32]))
+let foo1 = (\x -> (return $ x+1 :: R Double))
+let foo2 = (\x -> (return $ map (+1) x :: R [Int32]))
 
 -- Should be [1] 2
 H.print =<< [r| (function(x).Call(foo1_hs,x))(2) |]
@@ -56,21 +56,21 @@ H.unsafeRunInRThread (H.unsafeRunInRThread $ H.print H.nilValue)
 let fromSomeSEXP s = R.unSomeSEXP s H.fromSEXP
 
 -- Should be [1] 3
-let foo3 = (\n -> fmap fromSomeSEXP [r| n_hs |]) :: Int32 -> R s Int32
+let foo3 = (\n -> fmap fromSomeSEXP [r| n_hs |]) :: Int32 -> R Int32
 H.print =<< [r| foo3_hs(as.integer(3)) |]
 
 -- | should be 3
-let foo4 = (\n m -> return $ n + m) :: Double -> Double -> R s Double
+let foo4 = (\n m -> return $ n + m) :: Double -> Double -> R Double
 H.print =<< [r| foo4_hs(33, 66) |]
 
 -- Should be [1] 120 but it doesn't work
-let fact n = if n == (0 :: Int32) then (return 1 :: R s Int32) else fmap fromSomeSEXP [r| as.integer(n_hs * fact_hs(as.integer(n_hs - 1))) |]
+let fact n = if n == (0 :: Int32) then (return 1 :: R Int32) else fmap fromSomeSEXP [r| as.integer(n_hs * fact_hs(as.integer(n_hs - 1))) |]
 H.print =<< [r| fact_hs(as.integer(5)) |]
 
 :set -XDataKinds
 -- Should be [1] 29
-let foo5  = (\n -> return (n+1)) :: Int32 -> R s Int32
-let apply = (\n m -> [r| .Call(n_hs, m_hs) |]) :: R.Callback -> Int32 -> R s R.SomeSEXP
+let foo5  = (\n -> return (n+1)) :: Int32 -> R Int32
+let apply = (\n m -> [r| .Call(n_hs, m_hs) |]) :: R.Callback -> Int32 -> R R.SomeSEXP
 H.print =<< [r| apply_hs(foo5_hs, as.integer(28) ) |]
 
 sym <- H.install "blah"
@@ -87,7 +87,7 @@ H.print =<< [r| base::`+`(10,10) |]
 _ <- [r| `+` <- base::`+` |]
 
 :{
-let hFib :: Foreign.R.SEXP Foreign.R.Int -> H.Prelude.R s (Foreign.R.SEXP Foreign.R.Int)
+let hFib :: Foreign.R.SEXP Foreign.R.Int -> H.Prelude.R (Foreign.R.SEXP Foreign.R.Int)
     hFib n@(H.fromSEXP -> (0 :: Int32)) = fmap (flip R.asTypeOf n) [r| as.integer(0) |]
     hFib n@(H.fromSEXP -> (1 :: Int32)) = fmap (flip R.asTypeOf n) [r| as.integer(1) |]
     hFib n                              = H.withProtected (return n) $ const $

--- a/tests/test-compile-qq.hs
+++ b/tests/test-compile-qq.hs
@@ -48,7 +48,7 @@ main = do
       else putStrLn "OK"
     else rTests
 
-hFib :: SEXP R.Int -> R s (SEXP R.Int)
+hFib :: SEXP R.Int -> R (SEXP R.Int)
 hFib n@(fromSEXP -> (0 :: Int32)) = fmap (flip R.asTypeOf n) [r| as.integer(0) |]
 hFib n@(fromSEXP -> (1 :: Int32))  = fmap (flip R.asTypeOf n) [r| as.integer(1) |]
 hFib n                            = withProtected (return n) $ const $
@@ -97,8 +97,8 @@ rTests = H.runR H.defaultConfig $ do
 
     -- Should be [1] 1 2 3 4 5 6 7 8 9 10
     H.print =<< [r| y <- c(1:10) |]
-    let foo1 = (\x -> (return $ x+1 :: R s Double))
-    let foo2 = (\x -> (return $ map (+1) x :: R s [Int32]))
+    let foo1 = (\x -> (return $ x+1 :: R Double))
+    let foo2 = (\x -> (return $ map (+1) x :: R [Int32]))
 
     -- Should be [1] 2
     H.print =<< [r| (function(x).Call(foo1_hs,x))(2) |]
@@ -122,20 +122,20 @@ rTests = H.runR H.defaultConfig $ do
     let fromSomeSEXP s = R.unSomeSEXP s H.fromSEXP
 
     -- Should be [1] 3
-    let foo3 = (\n -> fmap fromSomeSEXP [r| n_hs |]) :: Int32 -> R s Int32
+    let foo3 = (\n -> fmap fromSomeSEXP [r| n_hs |]) :: Int32 -> R Int32
     H.print =<< [r| foo3_hs(as.integer(3)) |]
 
     -- | should be 99
-    let foo4 = (\n m -> return $ n + m) :: Double -> Double -> R s Double
+    let foo4 = (\n m -> return $ n + m) :: Double -> Double -> R Double
     H.print =<< [r| foo4_hs(33, 66) |]
 
     -- Should be [1] 120 but it doesn't work
-    let fact n = if n == (0 :: Int32) then (return 1 :: R s Int32) else fmap fromSomeSEXP [r| as.integer(n_hs * fact_hs(as.integer(n_hs - 1))) |]
+    let fact n = if n == (0 :: Int32) then (return 1 :: R Int32) else fmap fromSomeSEXP [r| as.integer(n_hs * fact_hs(as.integer(n_hs - 1))) |]
     H.print =<< [r| fact_hs(as.integer(5)) |]
 
     -- Should be [1] 29
-    let foo5  = \(n :: Int32) -> return (n+1) :: R s Int32
-    let apply = \(n :: R.Callback) (m :: Int32) -> [r| .Call(n_hs, m_hs) |] :: R s R.SomeSEXP
+    let foo5  = \(n :: Int32) -> return (n+1) :: R Int32
+    let apply = \(n :: R.Callback) (m :: Int32) -> [r| .Call(n_hs, m_hs) |] :: R R.SomeSEXP
     H.print =<< [r| apply_hs(foo5_hs, as.integer(28) ) |]
 
     sym <- H.install "blah"

--- a/tests/tests.hs
+++ b/tests/tests.hs
@@ -163,14 +163,14 @@ unitTests = testGroup "Unit tests"
       (((3::Double) @=?) =<<) $ fmap fromSEXP $
           alloca $ \p -> do
             e <- peek R.globalEnv
-            R.withProtected (return $ mkSEXP $ \x -> return $ x + 1 :: R s Double) $
+            R.withProtected (return $ mkSEXP $ \x -> return $ x + 1 :: R Double) $
               \sf -> R.unSomeSEXP (R.r2 (Data.ByteString.Char8.pack ".Call")
                                         sf
                                         (mkSEXP (2::Double))) $
                                   \s -> R.cast R.Real <$> R.tryEval s e p
   , testCase "Weak Ptr test" $ unsafeRunInRThread $ do
-      key  <- return $ mkSEXP (return 4 :: R s Int32)
-      val  <- return $ mkSEXP (return 5 :: R s Int32)
+      key  <- return $ mkSEXP (return 4 :: R Int32)
+      val  <- return $ mkSEXP (return 5 :: R Int32)
       True <- return $ R.typeOf val == R.ExtPtr
       rf   <- R.mkWeakRef key val (H.unhexp H.Nil) True 
       True <- case H.hexp rf of


### PR DESCRIPTION
Since the phantom type parameter of `R s a` has no use yet,
we are removing it.
