### PR TITLE
Protect R value in qq.ghci.

### DIFF
--- a/tests/ghci/qq.ghci
+++ b/tests/ghci/qq.ghci
@@ -105,7 +105,7 @@ H.print =<< [r| x <- new("x-test") |]
 -- instantiate and object and pass it to H as-is
 x <- [r| new("x-test") |]
 -- prevent x from being garbage collected
-_ <- H.newSomeRVal x
+rv <- H.newSomeRVal x
 -- show object
 H.print x
 -- Should be 1. Use slot accessor on R object.


### PR DESCRIPTION
We were using `_ <- newSomeRVal x` to protect `x`. Naturaly, ghci
sees no reason to hold a reference to the result of newSomRVal since
it has no name. In this patch we give it a name so ghci agrees to
keep it.
