### PR TITLE
Additional documentation about `hexp`.

### DIFF
--- a/doc/H-user.md
+++ b/doc/H-user.md
@@ -228,26 +228,80 @@ f (hexp -> Lang rator (hexp -> List rand1 (hexp -> List rand2 _ _) _) = …
 f (hexp -> Closure args body@(hexp -> Lang _ _) env) = ...
 ```
 
-The fact that `hexp` is defined as a pure function introduces a caveat.
-The user needs to make sure that the `SEXP` given to `hexp` has not been
-released at the time hexp is evaluated. The following program wouldn't
-work:
+### R values and side effects
 
-```Haskell
-main = do
-    () <- runR defaultConfig $ return
-            $ (\(Int s) -> ())
-            $ hexp
-            $ mkSEXP (1 :: Int32)
-    return ()
+As explained previously, values of type `SEXP a` are in fact pointers
+to structures stored on the R heap, an area of memory managed by the
+R interpreter. As such, one must take heed of the following two
+observations when using a pure function such as `hexp` to dereference
+such pointers.
+
+First, just like regular Haskell values are allocated on the GHC heap
+and managed by the GHC runtime, values pointed to by `SEXP`'s are
+allocated on the R heap, managed by the R runtime. Therefore, the
+lifetime of a SEXP value cannot extrude the lifetime of the R runtime
+itself, just as any Haskell value becomes garbage once the GHC runtime
+is terminated. That is, never invoke `hexp` on a value outside of the
+dynamic scope of `runR`. This isn't a problem in practice, because
+`runR` should be invoked only once, in the `main` function of the
+program`, just as the GHC runtime is initialized and terminated only
+once, at the entry point of the binary (i.e., C's main() function).
+
+The second observation is that the `hexp` view function does pointer
+dereferencing, which is a side-effect, yet it claims to be a pure
+function. The pointer that is being dereferenced is the argument to
+the function, of type `SEXP a`. The reason dereferencing a pointer is
+considered an effect is because its value depends on the state of the
+global memory at the time when it occurs. This is because a pointer
+identifies a memory location, called a *cell*, whose content can be
+mutated.
+
+Why then, does `hexp` claim to be pure? The reason is that H assumes
+and encourages a restricted mode of use of R that rules out mutation
+of the content of any cell. In the absence of mutation, dereferencing
+a pointer will always yield the same value, so no longer needs to be
+classified as an effect. The restricted mode of use in question bans
+any use of side-effects that break referential transparency. So-called
+*benign* side-effects, extremely common in R, do not compromise
+referential transparency and so are allowed.
+
+Is such an assumption reasonable? After all, many R functions use
+mutation and other side effects internally. However, it is also the
+case that R uses *value semantics*, not *reference semantics*. That
+is, including when passing arguments to functions, variables are
+always bound to values, not to references to those values. Therefore,
+given *e.g.* a global binding `x <- c(1, 2, 3)`, no call to any
+function `f(x)` will alter the *value* of x, because all side-effects
+of functions act on *copies* of `x` (the formal parameter of the
+function doesn't share a reference). For example:
+
+```R
+> x <- c(1,2,3)
+> f <- function(y) y[1] <- 42
+> f(x)
+> x
+[1] 1 2 3
 ```
 
-This program would fail because hexp is evaluated when pattern matching the
-result of `runR`. And in turn, this can happen only after `runR` has
-terminated the R interpreter thus invalidating the argument of `hexp`.
+Furthermore, in R, closures capture copies of their environment, so
+that even the following preserves the value of `x`:
 
-Similarly, the user needs to consider what the value of the `SEXP` will be
-when evaluating `hexp`. Consider the following program:
+```R
+> x <- c(1,2,3)
+> f <- function() x[1] <- 42
+> f()
+> x
+[1] 1 2 3
+```
+
+The upshot is that due to its value semantics, R effectively limits
+the scope of any mutation effects to the lexical scope of the
+function. Therefore, any function whose only side-effect is mutation
+is safe to call from a pure context.
+
+Conversely, evaluating any `SEXP` in a pure context in Haskell is
+*unsafe* in the presence of mutation of the global environment. For
+example,
 
 ```Haskell
 f :: SEXP a -> (R s SomeSEXP,HExp a)
@@ -258,6 +312,10 @@ f x = let h = hexp x
 The value of the expression `snd (f x)` depends on whether it is evaluated
 before or after evaluating the monadic computation `fst (f x)`.
 
+*Note:* H merely encourages, but has of course no way of *enforcing*
+a principled use of R that keeps to benign side-effects, because owing
+to the dynamic typing of R code, there is no precise static analysis
+that can detect bad side-effects.
 
 ### Physical and structural equality on R values
 


### PR DESCRIPTION
Section explaining when `hexp` is safe and when it's not.
