### PR TITLE
Fix uncaught exceptions problem.

### DIFF
--- a/src/Language/R/Literal.hs
+++ b/src/Language/R/Literal.hs
@@ -162,7 +162,7 @@ instance Literal a la => HFunWrap (R a) (IO (SEXP la)) where
 
 instance (Literal a la, HFunWrap b wb)
          => HFunWrap (a -> b) (SEXP la -> wb) where
-    hFunWrap f a = hFunWrap $ f $ fromSEXP a
+    hFunWrap f a = hFunWrap $ f $! fromSEXP a
 
 foreign import ccall "missing_r.h funPtrToSEXP" funPtrToSEXP
     :: FunPtr a -> IO (SEXP R.ExtPtr)


### PR DESCRIPTION
Currently in case if we have a type error between R and Haskell,
user will see an uncaught exception:

LanguageziRziInternalziFunWrappers_dB31: uncaught exception

This patch fixes this problem.
