### PR TITLE
Remove unsafePerformIO calls in Laguage.R and H.print.

### DIFF
--- a/src/Language/R.hs
+++ b/src/Language/R.hs
@@ -53,7 +53,6 @@ import Foreign
     , peek
     )
 import Foreign.C.String ( withCString, peekCString )
-import System.IO.Unsafe ( unsafePerformIO )
 
 -- | Parse and then evaluate expression.
 parseEval :: ByteString -> IO SomeSEXP
@@ -76,20 +75,16 @@ parseEval txt = useAsCString txt $ \ctxt ->
 -- | Call a pure unary R function of the given name in the global environment.
 --
 -- This function is here mainly for testing purposes.
-r1 :: ByteString -> SEXP a -> SomeSEXP
+r1 :: ByteString -> SEXP a -> IO SomeSEXP
 r1 fn a =
-    unsafePerformIO $
-      useAsCString fn $ \cfn -> R.install cfn >>= \f ->
-        withProtected (R.lang2 f a) evalIO
-{-# NOINLINE r1 #-}
+    useAsCString fn $ \cfn -> R.install cfn >>= \f ->
+      withProtected (R.lang2 f a) evalIO
 
 -- | Call a pure binary R function. See 'r1' for additional comments.
-r2 :: ByteString -> SEXP a -> SEXP b -> SomeSEXP
+r2 :: ByteString -> SEXP a -> SEXP b -> IO SomeSEXP
 r2 fn a b =
-    unsafePerformIO $
-      useAsCString fn $ \cfn -> R.install cfn >>= \f ->
+    useAsCString fn $ \cfn -> R.install cfn >>= \f ->
       withProtected (R.lang3 f a b) evalIO
-{-# NOINLINE r2 #-}
 
 -- | Parse file and perform some actions on parsed file.
 --
@@ -101,8 +96,8 @@ parseFile :: FilePath -> (SEXP R.Expr -> IO a) -> IO a
 parseFile fl f = do
     withCString fl $ \cfl ->
       withProtected (R.mkString cfl) $ \rfl ->
-        case r1 (C8.pack "parse") rfl of
-          R.SomeSEXP s -> return (R.unsafeCoerce s) `withProtected` f
+        r1 (C8.pack "parse") rfl >>= \(R.SomeSEXP s) ->
+          return (R.unsafeCoerce s) `withProtected` f
 
 parseText :: String                               -- ^ Text to parse
           -> Bool                                 -- ^ Whether to annotate the

--- a/tests/tests.hs
+++ b/tests/tests.hs
@@ -164,10 +164,10 @@ unitTests = testGroup "Unit tests"
           alloca $ \p -> do
             e <- peek R.globalEnv
             R.withProtected (return $ mkSEXP $ \x -> return $ x + 1 :: R Double) $
-              \sf -> R.unSomeSEXP (R.r2 (Data.ByteString.Char8.pack ".Call")
-                                        sf
-                                        (mkSEXP (2::Double))) $
-                                  \s -> R.cast R.Real <$> R.tryEval s e p
+              \sf -> R.r2 (Data.ByteString.Char8.pack ".Call")
+                          sf
+                          (mkSEXP (2::Double))
+                     >>= \(R.SomeSEXP s) -> R.cast R.Real <$> R.tryEval s e p
   , testCase "Weak Ptr test" $ unsafeRunInRThread $ do
       key  <- return $ mkSEXP (return 4 :: R Int32)
       val  <- return $ mkSEXP (return 5 :: R Int32)


### PR DESCRIPTION
H.print was using a pure show unnecessarily. Also, the need for a pure style of r1 and r2 was not justified at call sites.
