### PR TITLE
Install manuals using cabal

### DIFF
--- a/H.cabal
+++ b/H.cabal
@@ -38,6 +38,7 @@ extra-source-files:   cbits/Hcompat.h
                       doc/H-ints.md
                       doc/H-user.md
                       doc/pandoc.css
+                      Makefile
 
 source-repository head
   type:     git

--- a/Makefile
+++ b/Makefile
@@ -55,14 +55,14 @@ test: $(CONFIGURE)
 run: $(CONFIGURE)
 	cabal run -- --interactive -- -package-db .cabal-sandbox/*-packages.conf.d -package-db dist/package.conf.inplace
 
-dist/pandoc/H-ints.html: doc/H-ints.md doc/pandoc.css
-	mkdir -p dist/pandoc
-	cp doc/pandoc.css dist/pandoc
+dist/doc/pandoc/H-ints.html: doc/H-ints.md doc/pandoc.css
+	mkdir -p dist/doc/pandoc
+	cp doc/pandoc.css dist/doc/pandoc
 	pandoc -f markdown --mathjax -s -S --toc -c pandoc.css $< -o $@
 
-dist/pandoc/H-user.html: doc/H-user.md doc/pandoc.css
-	mkdir -p dist/pandoc
-	cp doc/pandoc.css dist/pandoc
+dist/doc/pandoc/H-user.html: doc/H-user.md doc/pandoc.css
+	mkdir -p dist/doc/pandoc
+	cp doc/pandoc.css dist/doc/pandoc
 	pandoc -f markdown --mathjax -s -S --toc -c pandoc.css $< -o $@
 
 # NOTE: Passing `--ghc-options=-optP-P` is a workaround for an issue with
@@ -71,7 +71,9 @@ dist/pandoc/H-user.html: doc/H-user.md doc/pandoc.css
 doc-haddock: $(CONFIGURE)
 	cabal haddock --ghc-options=-optP-P --hyperlink-source
 
-doc: doc-haddock dist/pandoc/H-ints.html dist/pandoc/H-user.html
+doc-manuals: dist/doc/pandoc/H-ints.html dist/doc/pandoc/H-user.html
+
+doc: doc-haddock doc-manuals
 
 # TODO: Investigate coverage.
 coverage:


### PR DESCRIPTION
I have revealed this part of PR and addressed all comments from the previous PR.

The one question that is left is: do we want to reuse `make doc` command to build documentation or we can call  pandoc from Setup.hs directly.
