### PR TITLE
Fix tests.

### DIFF
--- a/tests/Test/RVal.hs
+++ b/tests/Test/RVal.hs
@@ -20,8 +20,7 @@ tests = testGroup "HVal"
     [ testCase "RVal is not collected by R GC" $
       bracket getCurrentDirectory setCurrentDirectory $ const $ do
         ((assertBool "RVal was collected" . isInt) =<<) $ do
-            -- double initialization, but it's safe
-            R.runR R.defaultConfig $ do
+            unsafeRunInRThread $ unsafeRToIO $ do
               x <- newRVal =<< io (R.allocVector SingR.SInt 1024 :: IO (R.SEXP R.Int))
               io $ R.gc
               withRVal x (return . R.typeOf)

--- a/tests/tests.hs
+++ b/tests/tests.hs
@@ -183,6 +183,7 @@ unitTests = testGroup "Unit tests"
   , Test.Constraints.tests
   , Test.FunPtr.tests
   , Test.RVal.tests
+  , testCase "sanity check " $ unsafeRunInRThread $ return ()
   ]
 
 integrationTests :: TestTree


### PR DESCRIPTION
RVal test used `runR` it caused to deallocation of the R runtime,
and it was not possible to write any of the tests after it.
This commit fixes situation by using unsafe operations to run tests.
