### PR TITLE
Has H indicate that it has not been initialized.

### DIFF
--- a/cbits/missing_r.c
+++ b/cbits/missing_r.c
@@ -57,7 +57,8 @@ void processGUIEventsUnix(InputHandler** inputHandlers) {
 int isRInitialized = 2;
 
 HsStablePtr rVariables;
-HsStablePtr interpreterChan;
+// Here we have the same problem with initialization as in isRInitialized above.
+HsStablePtr interpreterChan = (HsStablePtr)2;
 
 #undef USE_RINTERNALS
 


### PR DESCRIPTION
The following program

``` Haskell
import Data.Int
import H.Prelude

main = do
    _ <- runR defaultConfig $ newRVal =<< io (mkSEXPIO (42 :: Int32))
    unsafeRunInRThread $ return ()
```

now fails with

```
$ ./testH
testH: postToRThread_: H is not initialized.
```
