### PR TITLE
Get rid of pointers workaround.

### DIFF
--- a/H.cabal
+++ b/H.cabal
@@ -74,7 +74,7 @@ library
                        Control.Monad.R.Class
                        H.Internal.Error
                        H.Internal.Prelude
-  build-depends:       base >= 4.6 && < 5
+  build-depends:       base >= 4.7 && < 5
                      , aeson >= 0.6
                      , bytestring >= 0.10
                      , pretty >= 1.1
@@ -126,7 +126,7 @@ library
 executable H
   main-is:             src/Main.hs
   build-depends:       H
-                     , base >= 4.6 && < 5
+                     , base >= 4.7 && < 5
                      , bytestring >= 0.10
                      , cmdargs >= 0.10.5
                      , pretty >= 1.1
@@ -156,7 +156,7 @@ test-suite tests
   main-is:             tests.hs
   type:                exitcode-stdio-1.0
   build-depends:       H
-                     , base >= 4.6 && < 5
+                     , base >= 4.7 && < 5
                      , bytestring >= 0.10
                      , directory >= 1.2
                      , filepath >= 1.3
@@ -181,7 +181,7 @@ test-suite test-compile-qq
   main-is:             test-compile-qq.hs
   type:                exitcode-stdio-1.0
   build-depends:       H
-                     , base >= 4.6 && < 5
+                     , base >= 4.7 && < 5
                      , process >= 1.2
   ghc-options:         -Wall -threaded
   hs-source-dirs:      tests
@@ -191,7 +191,7 @@ test-suite test-shootout-programs
   main-is:             test-shootout-programs.hs
   type:                exitcode-stdio-1.0
   build-depends:       H
-                     , base >= 4.6 && < 5
+                     , base >= 4.7 && < 5
                      , filepath >= 1.3
                      , process >= 1.2
   ghc-options:         -Wall -threaded
@@ -222,7 +222,7 @@ benchmark compile-qq-benchmarks
   main-is:             compile-qq-benchmarks.hs
   type:                exitcode-stdio-1.0
   build-depends:       H
-                     , base >= 4.6 && < 5
+                     , base >= 4.7 && < 5
                      , criterion >= 0.8
                      , filepath >= 1.3
                      , process >= 1.2
@@ -235,7 +235,7 @@ benchmark runtime-qq-benchmarks
   main-is:             runtime-qq-benchmarks.hs
   type:                exitcode-stdio-1.0
   build-depends:       H
-                     , base >= 4.6 && < 5
+                     , base >= 4.7 && < 5
                      , filepath >= 1.3
                      , process >= 1.2
   ghc-options:         -Wall -threaded
@@ -246,7 +246,7 @@ benchmark hexp-benchmark
   main-is:             hexp-bench.hs
   type:                exitcode-stdio-1.0
   build-depends:       H
-                     , base >= 4.6 && < 5
+                     , base >= 4.7 && < 5
                      , criterion >= 0.8
                      , primitive >= 0.5
                      , vector >= 0.10

--- a/H.ghci
+++ b/H.ghci
@@ -13,15 +13,4 @@ import Foreign.R as R (SEXP, SomeSEXP(..), SEXPTYPE, SEXPInfo)
 import Language.R as R (R)
 import Language.R.QQ as H (r, rexp, rsafe)
 
-:{
-Language.R.pokeRVariables
-    ( Foreign.R.globalEnv
-    , Foreign.R.baseEnv
-    , Foreign.R.nilValue
-    , Foreign.R.unboundValue
-    , Foreign.R.missingArg
-    , Foreign.R.rInteractive
-    , Foreign.R.rInputHandlers
-    )
-:}
 Language.R.Instance.initialize Language.R.Instance.defaultConfig

--- a/cbits/missing_r.c
+++ b/cbits/missing_r.c
@@ -56,7 +56,6 @@ void processGUIEventsUnix(InputHandler** inputHandlers) {
 // a linking error in Windows x64. But initializing to 2 poses no problem!
 int isRInitialized = 2;
 
-HsStablePtr rVariables;
 // Here we have the same problem with initialization as in isRInitialized above.
 HsStablePtr interpreterChan = (HsStablePtr)2;
 

--- a/cbits/missing_r.h
+++ b/cbits/missing_r.h
@@ -19,9 +19,6 @@ void processGUIEventsUnix(InputHandler** inputHandlers);
 // Indicates whether R has been initialized.
 extern int isRInitialized;
 
-// R global variables for GHCi.
-extern HsStablePtr rVariables;
-
 // Pointer to the channel used for communication with the R thread.
 extern HsStablePtr interpreterChan;
 

--- a/src/Language/R.hs
+++ b/src/Language/R.hs
@@ -59,7 +59,7 @@ parseEval :: ByteString -> IO SomeSEXP
 parseEval txt = useAsCString txt $ \ctxt ->
   withProtected (R.mkString ctxt) $ \rtxt ->
     alloca $ \status -> do
-      nil <- peek nilValuePtr
+      nil <- peek R.nilValue
       withProtected (R.parseVector rtxt 1 status nil) $ \exprs -> do
         rc <- fromIntegral <$> peek status
         unless (R.PARSE_OK == toEnum rc) $
@@ -147,7 +147,7 @@ evalEnvIO x rho =
 
 -- | Evaluate an expression in the global environment.
 evalIO :: SEXP a -> IO SomeSEXP
-evalIO x = peek globalEnvPtr >>= evalEnvIO x
+evalIO x = peek R.globalEnv >>= evalEnvIO x
 
 evalEnv :: MonadR m => SEXP a -> SEXP R.Env -> m SomeSEXP
 evalEnv = (io .). evalEnvIO

--- a/src/Language/R/Globals.hs
+++ b/src/Language/R/Globals.hs
@@ -13,22 +13,22 @@ module Language.R.Globals
 
 import Foreign ( peek )
 import Foreign.R  (SEXP, SEXPTYPE(..))
-import qualified Language.R.Instance as R
+import qualified Foreign.R as R
 import System.IO.Unsafe ( unsafePerformIO )
 
 -- | Special value to which all symbols unbound in the current environment
 -- resolve to.
 unboundValue :: SEXP Symbol
-unboundValue = unsafePerformIO $ peek R.unboundValuePtr
+unboundValue = unsafePerformIO $ peek R.unboundValue
 
 -- | R's @NULL@ value.
 nilValue :: SEXP Nil
-nilValue = unsafePerformIO $ peek R.nilValuePtr
+nilValue = unsafePerformIO $ peek R.nilValue
 
 -- | Value substituted for all missing actual arguments of a function call.
 missingArg :: SEXP Symbol
-missingArg = unsafePerformIO $ peek R.missingArgPtr
+missingArg = unsafePerformIO $ peek R.missingArg
 
 -- | The global environment.
 globalEnv :: SEXP Env
-globalEnv = unsafePerformIO $ peek R.globalEnvPtr
+globalEnv = unsafePerformIO $ peek R.globalEnv


### PR DESCRIPTION
GHC bug number #8549 was fixed in ghc-7.8.2, this allowes to
remove pointers workaround code from Language.R.Instance.

[1] https://ghc.haskell.org/trac/ghc/ticket/8549#ticket
