### PR TITLE
Introduce new tests that will reveal race condition.

### DIFF
--- a/tests/tests.hs
+++ b/tests/tests.hs
@@ -5,6 +5,7 @@
 -- comparing the output of H with the output of R.
 
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE QuasiQuotes #-}
 module Main where
 
 import qualified Test.Constraints
@@ -21,6 +22,7 @@ import qualified Language.R.Instance as R
 import qualified Language.R as R
     ( withProtected
     , r2 )
+import           Language.R.QQ
 
 import Test.Tasty hiding (defaultMain)
 import Test.Tasty.Golden.Advanced
@@ -183,6 +185,7 @@ unitTests = testGroup "Unit tests"
   , Test.Constraints.tests
   , Test.FunPtr.tests
   , Test.RVal.tests
+  , testCase "qq/double-initialization" $ unsafeRunInRThread $ unsafeRToIO $ [r| 1 |] >> return ()
   , testCase "sanity check " $ unsafeRunInRThread $ return ()
   ]
 


### PR DESCRIPTION
Race condition in R initialization was not revealed by existing
tests, this commit introduces a minimal required addition to tests
that will reveal a problem with existing set of tests.
In order to show race we need to make ghc compile 2 Quasi-Quotes in
the same time. Introducing a special test will not help here as
we may see a different behaviour on each run and because if we don't
hit in a race a false-positive result will be reported.
In order to reproduce a result following things should hold:
1. QQ should exist in a module A, that depends on B and C
2. QQ should exist in B
3. QQ should exist in C

Once we have all three prerequences the error will happen.
However, it's possible to see different behaviours, they are:
- Message "R is already initialized"
- Segfault in compiler
- R error message about corrupted memory.

The only common this is a fail of compilation, and we check it
during the build of the tests in CI.
