### PR TITLE
Update API of the Literal module.

### DIFF
--- a/src/Language/R/Literal.hs
+++ b/src/Language/R/Literal.hs
@@ -22,6 +22,7 @@ module Language.R.Literal
     -- * wrapper helpers
   ) where
 
+import           Control.Memory.Region
 import           H.Internal.Prelude
 import           Language.R.HExp
 import           Language.R.Internal.FunWrappers
@@ -43,16 +44,16 @@ import System.IO.Unsafe ( unsafePerformIO )
 
 -- | Values that can be converted to 'SEXP'.
 class Literal a b | a -> b where
-    mkSEXPIO :: a -> IO (SEXP s b)
-    -- XXX: should be `a -> IO (SEXP V b)`
-    -- The problem here is that SEXP is not protected, so effectively
-    -- it's in a void region, except the cases when 'a' is protected
-    -- in 's'.
+    -- | Low level function for creation a SEXP value.
+    -- This function work in IO monad and doesn't protect
+    -- a value, in most cases you are interested in 'mkSEXP'
+    -- function that does a protection.
+    mkSEXPIO :: a -> IO (SEXP V b)
     fromSEXP :: SEXP s c -> a
 
-{-# NOINLINE mkSEXP #-}
-mkSEXP :: Literal a b => a -> SEXP s b
-mkSEXP = unsafePerformIO . mkSEXPIO
+-- |  Create a SEXP value and protect it in current region
+mkSEXP :: (Literal a b, MonadR m) => a -> m (SEXP (Region m) b)
+mkSEXP x = acquire =<< io (mkSEXPIO x)
 
 {-# NOINLINE mkSEXPVector #-}
 mkSEXPVector :: (Storable (SVector.ElemRep s a), IsVector a)

--- a/tests/Test/FunPtr.hs
+++ b/tests/Test/FunPtr.hs
@@ -28,7 +28,7 @@ import Control.Applicative
 import Control.Concurrent.MVar
 import Control.Monad
 import Data.ByteString.Char8
-import Foreign (FunPtr, castFunPtr, peek)
+import Foreign (FunPtr, castFunPtr)
 import System.Mem.Weak
 import System.Mem
 
@@ -51,8 +51,9 @@ tests = testGroup "funptr"
   [ testCase "funptr is freed from R" $ do
       ((Nothing @=?) =<<) $ do
          hwr <- HaveWeak return <$> newEmptyMVar
-         _ <- R.withProtected (return $ mkSEXP hwr) $
-           \sf -> return $ R.r2 (Data.ByteString.Char8.pack ".Call") sf (mkSEXP (2::Double))
+         _ <- R.withProtected (mkSEXPIO hwr) $
+           \sf -> R.withProtected (mkSEXPIO (2::Double)) $ \z ->
+                     return $ R.r2 (Data.ByteString.Char8.pack ".Call") sf z
          replicateM_ 10 (R.allocVector SingR.SReal 1024 :: IO (R.SEXP V R.Real))
          replicateM_ 10 R.gc
          replicateM_ 10 performGC

--- a/tests/Test/HExp.hs
+++ b/tests/Test/HExp.hs
@@ -5,7 +5,6 @@ import H.Constraints
 import qualified Language.R.HExp as H
 import           Language.R as R
 import           Foreign.R as R hiding (withProtected)
-import           Language.R.QQ
 
 import Foreign.C
 

--- a/tests/compile-qq-benchmarks.hs
+++ b/tests/compile-qq-benchmarks.hs
@@ -43,6 +43,6 @@ main = do
                    , bench "compile-time-qq" $
                        unsafeRToIO [r| fib(18) |]
                    , bench "compile-time-qq-hybrid" $
-                       unsafeRToIO $ hFib $! mkSEXP (18 :: Int32)
+                       unsafeRToIO $ hFib =<< mkSEXP (18 :: Int32)
                    ]
                ]

--- a/tests/hexp-bench.hs
+++ b/tests/hexp-bench.hs
@@ -24,7 +24,7 @@
 import Foreign.R (integer, SEXP, SomeSEXP(..))
 import qualified Foreign.R as R (SSEXPTYPE, SEXPTYPE(Int), typeOf, cast)
 import H.Prelude (withEmbeddedR, defaultConfig)
-import Language.R.Literal (mkSEXP)
+import Language.R.Literal (mkSEXPIO)
 import Language.R.HExp (hexp, HExp(..))
 import Data.Singletons (sing)
 
@@ -39,7 +39,7 @@ import System.IO.Unsafe (unsafePerformIO)
 
 main :: IO ()
 main = withEmbeddedR defaultConfig $ do
-    let x = mkSEXP (1 :: Int32)
+    x <- mkSEXPIO (1 :: Int32)
     defaultMain
       [ bgroup "vector access"
           [ bench "typeof>integer"   $ whnfIO $ benchInteger x

--- a/tests/test-compile-qq.hs
+++ b/tests/test-compile-qq.hs
@@ -59,7 +59,7 @@ rTests = H.withEmbeddedR H.defaultConfig $ runRegion $ do
 
     -- Should be [1] 4181
     -- Placing it before enabling gctorture2 for speed.
-    H.print =<< hFib (mkSEXP (19 :: Int32))
+    H.print =<< hFib =<< mkSEXP (19 :: Int32)
 
     _ <- [r| gctorture2(1,0,TRUE) |]
 

--- a/tests/tests.hs
+++ b/tests/tests.hs
@@ -147,21 +147,25 @@ ghciSession name scriptPath =
 
 unitTests :: TestTree
 unitTests = testGroup "Unit tests"
-  [ testCase "fromSEXP . mkSEXP" $ unsafeRunInRThread $
-      (2 :: Double) @=? fromSEXP (mkSEXP (2 :: Double))
+  [ testCase "fromSEXP . mkSEXP" $ unsafeRunInRThread $ do
+      z <- fromSEXP <$> mkSEXPIO (2 :: Double)
+      (2 :: Double) @=? z
   , testCase "HEq HExp" $ unsafeRunInRThread $ do
       -- XXX ideally randomly generate input.
       let x = 2 :: Double
-      assertBool "reflexive" $
-          let s = H.hexp $ mkSEXP x in s === s
-      assertBool "symmetric" $
-          let s1 = H.hexp $ mkSEXP x
-              s2 = H.hexp $ mkSEXP x
+      R.withProtected (mkSEXPIO x) $ \z ->
+        assertBool "reflexive" $
+          let s = H.hexp z in s === s
+      R.withProtected (mkSEXPIO x) $ \z ->
+        assertBool "symmetric" $
+          let s1 = H.hexp z
+              s2 = H.hexp z
           in s1 === s2 && s2 === s1
-      assertBool "transitive" $
-          let s1 = H.hexp $ mkSEXP x
-              s2 = H.hexp $ mkSEXP x
-              s3 = H.hexp $ mkSEXP x
+      R.withProtected (mkSEXPIO x) $ \z ->
+        assertBool "transitive" $
+          let s1 = H.hexp z
+              s2 = H.hexp z
+              s3 = H.hexp z
           in s1 === s2 && s2 === s3 && s1 === s3
   , testCase "Haskell function from R" $ unsafeRunInRThread $ do
 --      (("[1] 3.0" @=?) =<<) $
@@ -169,14 +173,14 @@ unitTests = testGroup "Unit tests"
       (((3::Double) @=?) =<<) $ fmap fromSEXP $
           alloca $ \p -> do
             e <- peek R.globalEnv
-            R.withProtected (return $ mkSEXP $ \x -> return $ x + 1 :: R s Double) $
-              \sf -> R.r2 (Data.ByteString.Char8.pack ".Call")
-                          sf
-                          (mkSEXP (2::Double))
-                     >>= \(R.SomeSEXP s) -> R.cast (sing :: R.SSEXPTYPE R.Real) <$> R.tryEval s (R.release e) p
+            R.withProtected (mkSEXPIO $ \x -> return $ x + 1 :: R s Double) $
+              \sf -> R.withProtected (mkSEXPIO (2::Double)) $ \d ->
+                      R.r2 (Data.ByteString.Char8.pack ".Call") sf d
+                      >>= \(R.SomeSEXP s) -> R.cast  (sing :: R.SSEXPTYPE R.Real)
+                                                     <$> R.tryEval s (R.release e) p
   , testCase "Weak Ptr test" $ unsafeRunInRThread $ runRegion $ do
-      key  <- return $ mkSEXP (return 4 :: R s Int32)
-      val  <- return $ mkSEXP (return 5 :: R s Int32)
+      key  <- mkSEXP (return 4 :: R s Int32)
+      val  <- mkSEXP (return 5 :: R s Int32)
       True <- return $ R.typeOf val == R.ExtPtr
       n    <- H.unhexp H.Nil
       rf   <- io $ R.mkWeakRef key val n True
@@ -188,11 +192,12 @@ unitTests = testGroup "Unit tests"
                 _ -> error "unexpected type"
       return ()
   , testCase "Hexp works" $ unsafeRunInRThread $
-      (((42::Double) @=?) =<<) $
-         let y = R.cast (sing :: R.SSEXPTYPE R.Real) (R.SomeSEXP (mkSEXP (42::Double)))
-         in case H.hexp y of
-              H.Bytecode -> return 15 
-              H.Real s -> basicUnsafeIndexM s 0
+      (((42::Double) @=?) =<<) $ runRegion $ do
+         y <- R.cast (sing :: R.SSEXPTYPE R.Real) . R.SomeSEXP
+                     <$> mkSEXP (42::Double)
+         case H.hexp y of
+           H.Bytecode -> return 15
+           H.Real s -> io $ basicUnsafeIndexM s 0
   , Test.Constraints.tests
   , Test.FunPtr.tests
   , Test.RVal.tests
@@ -223,3 +228,4 @@ main :: IO ()
 main = do
     _ <- R.initialize R.defaultConfig
     defaultMain tests
+


### PR DESCRIPTION
This change introduces a new API for literal instances:

Changes:

  mkSEXPIO     - create an unprotected SEXP in IO monad;
  mkSEXP       - create protected SEXP in R Monad;
