### PR TITLE
Remove `R_PPStackTop` binding. Move it to tests.

### DIFF
--- a/src/Foreign/R.chs
+++ b/src/Foreign/R.chs
@@ -139,7 +139,6 @@ module Foreign.R
   , release
   , unsafeRelease
   , withProtected
-  , ppStackTop
   ) where
 
 import Control.Memory.Region
@@ -659,5 +658,3 @@ withProtected create f =
       (do { x <- create; _ <- protect x; return x })
       (const $ unprotect 1)
       (f . unsafeRelease)
-
-foreign import ccall "&R_PPStackTop" ppStackTop :: Ptr Int


### PR DESCRIPTION
This symbol is internal to R, and so we should not bind to it. However,
for tests, it's currently the only way we have to check protection stack
balance. So where possible, we do bind to it, but only in tests.
