### PR TITLE
added fromSomeSEXP to Language.R.Literal

### DIFF
--- a/src/Language/R/Literal.hs
+++ b/src/Language/R/Literal.hs
@@ -12,6 +12,7 @@
 
 module Language.R.Literal
   ( Literal(..)
+  , fromSomeSEXP
   , mkSEXP
   , mkSEXPVector
   , mkSEXPVectorIO
@@ -31,7 +32,7 @@ import qualified Data.Vector.SEXP as SVector
 import qualified Foreign.R as R
 import           Foreign.R.Type ( IsVector, SSEXPTYPE )
 
-import Data.Singletons ( SingI, sing )
+import Data.Singletons ( Sing, SingI, sing )
 
 import Control.Monad ( void, zipWithM_ )
 import Data.Int (Int32)
@@ -47,6 +48,10 @@ class Literal a b | a -> b where
     -- probably want to be using 'mkSEXP' instead.
     mkSEXPIO :: a -> IO (SEXP V b)
     fromSEXP :: SEXP s c -> a
+
+-- | 'R.cast' from 'R.SomeSEXP' to a suitable Haskell type.
+fromSomeSEXP :: forall s a form. (Literal a form,SingI form) => R.SomeSEXP s -> a
+fromSomeSEXP = fromSEXP . R.cast (sing :: Sing form)
 
 -- |  Create a SEXP value and protect it in current region
 mkSEXP :: (Literal a b, MonadR m) => a -> m (SEXP (Region m) b)

--- a/tests/test-compile-qq.hs
+++ b/tests/test-compile-qq.hs
@@ -123,10 +123,10 @@ rTests = H.withEmbeddedR H.defaultConfig $ runRegion $ do
     -- Should be NULL
     H.print H.nilValue
 
-    let fromSomeSEXP s = R.unSomeSEXP s H.fromSEXP
+    let int32FromSomeSEXP x = H.fromSomeSEXP x :: Int32
 
     -- Should be [1] 3
-    let foo3 = (\n -> fmap fromSomeSEXP [r| n_hs |]) :: Int32 -> R s Int32
+    let foo3 = (\n -> fmap int32FromSomeSEXP [r| n_hs |]) :: Int32 -> R s Int32
     H.print =<< [r| foo3_hs(as.integer(3)) |]
 
     -- | should be 99
@@ -134,7 +134,7 @@ rTests = H.withEmbeddedR H.defaultConfig $ runRegion $ do
     H.print =<< [r| foo4_hs(33, 66) |]
 
     -- Should be [1] 120 but it doesn't work
-    let fact n = if n == (0 :: Int32) then (return 1 :: R s Int32) else fmap fromSomeSEXP [r| as.integer(n_hs * fact_hs(as.integer(n_hs - 1))) |]
+    let fact n = if n == (0 :: Int32) then (return 1 :: R s Int32) else fmap int32FromSomeSEXP [r| as.integer(n_hs * fact_hs(as.integer(n_hs - 1))) |]
     H.print =<< [r| fact_hs(as.integer(5)) |]
 
     -- Should be [1] 29


### PR DESCRIPTION
It casts a SomeEXP to the form determined (via Literal) by the return
type.
