### PR TITLE
Rewrite Literal instance for String.

### DIFF
--- a/inline-r/inline-r.cabal
+++ b/inline-r/inline-r.cabal
@@ -146,6 +146,7 @@ test-suite test-qq
                      , mtl >= 2.0
                      , process >= 1.2
                      , tasty-hunit >= 0.4.1
+                     , singletons >= 0.9
                      , text >= 0.11
   ghc-options:         -Wall -threaded
   hs-source-dirs:      tests

--- a/inline-r/tests/test-qq.hs
+++ b/inline-r/tests/test-qq.hs
@@ -23,6 +23,7 @@ import Control.Memory.Region
 import Control.Applicative ((<$>))
 import Control.Monad.Trans (liftIO)
 import Data.Int
+import Data.Singletons (sing)
 import qualified Data.Text.Lazy as Text
 import Test.Tasty.HUnit hiding ((@=?))
 
@@ -124,5 +125,8 @@ main = H.withEmbeddedR H.defaultConfig $ H.runRegion $ do
       return x
     ("c(7, 2, 3)" @=?) =<< [r| v = v1_hs; v[1] <- 7; v |]
     io $ assertEqual "" "fromList [1,2,3]" . Prelude.show =<< SVector.unsafeFreeze v1
+
+    let utf8string = "abcd çéõßø"
+    io . assertEqual "" utf8string =<< fromSEXP <$> R.cast (sing :: R.SSEXPTYPE 'R.String) <$> [r| utf8string_hs |]
 
     return ()


### PR DESCRIPTION
This rewrite addresses two issues simultaneously: the new instance
should deal with non-ASCII content better than previously (a test for
that is included). Further, String is now correctly lifted to the
STRINGSXP R form, rather than CHARSXP, which is mostly internal and
much less useful for end users.