### PR TITLE
added fromSomeSEXP to Language.R.Literal

### DIFF
--- a/inline-r/src/Language/R/Literal.hs
+++ b/inline-r/src/Language/R/Literal.hs
@@ -15,6 +15,7 @@
 
 module Language.R.Literal
   ( Literal(..)
+  , fromSomeSEXP
   , mkSEXP
   , mkSEXPVector
   , mkSEXPVectorIO
@@ -35,7 +36,7 @@ import qualified Data.Vector.SEXP.Mutable as SMVector
 import qualified Foreign.R as R
 import           Foreign.R.Type ( IsVector, SSEXPTYPE )
 
-import Data.Singletons ( SingI, sing )
+import Data.Singletons ( Sing, SingI, sing )
 
 import Control.Monad ( void, zipWithM_ )
 import Data.Char (chr)
@@ -52,6 +53,10 @@ class Literal a b | a -> b where
     -- probably want to be using 'mkSEXP' instead.
     mkSEXPIO :: a -> IO (SEXP V b)
     fromSEXP :: SEXP s c -> a
+
+-- | 'R.cast' from 'R.SomeSEXP' to a suitable Haskell type.
+fromSomeSEXP :: forall s a form. (Literal a form,SingI form) => R.SomeSEXP s -> a
+fromSomeSEXP = fromSEXP . R.cast (sing :: Sing form)
 
 -- |  Create a SEXP value and protect it in current region
 mkSEXP :: (Literal a b, MonadR m) => a -> m (SEXP (Region m) b)

--- a/inline-r/tests/test-qq.hs
+++ b/inline-r/tests/test-qq.hs
@@ -89,8 +89,6 @@ main = H.withEmbeddedR H.defaultConfig $ H.runRegion $ do
 
     ("NULL" @=?) H.nilValue
 
-    let fromSomeSEXP s = R.unSomeSEXP s H.fromSEXP
-
     let foo3 = (\n -> fmap fromSomeSEXP [r| n_hs |]) :: Int32 -> R s Int32
     ("3L" @=?) =<< [r| foo3_hs(as.integer(3)) |]
 


### PR DESCRIPTION
It casts a SomeEXP to the form determined (via Literal) by the return
type.