### PR TITLE
Add a PrimMonad instance for R.

### DIFF
--- a/inline-r/src/Language/R/Instance.hs
+++ b/inline-r/src/Language/R/Instance.hs
@@ -37,7 +37,9 @@ module Language.R.Instance
   , finalize
   ) where
 
+import           Control.Monad.Primitive (PrimMonad(..))
 import           Control.Monad.R.Class
+import           Control.Monad.ST.Unsafe (unsafeSTToIO)
 import           Data.Monoid
 import           Data.Default.Class (Default(..))
 import qualified Foreign.R as R
@@ -91,6 +93,10 @@ instance MonadR (R s) where
     x <- R.release <$> R.protect s
     modifyIORef' cnt succ
     return x
+
+instance PrimMonad (R s) where
+  type PrimState (R s) = s
+  primitive f = R $ lift $ unsafeSTToIO $ primitive f
 
 -- | Initialize a new instance of R, execute actions that interact with the
 -- R instance and then finalize the instance. This is typically called at the

--- a/inline-r/src/Language/R/Literal.hs
+++ b/inline-r/src/Language/R/Literal.hs
@@ -177,7 +177,7 @@ instance SVector.VECTOR V ty a => Literal (SVector.Vector V ty a) ty where
     mkSEXPIO = SVector.toSEXP
     fromSEXP = unsafePerformIO . SVector.freeze . fromSEXP
 
-instance SVector.VECTOR V ty a => Literal (SMVector.IOVector V ty a) ty where
+instance SVector.VECTOR V ty a => Literal (SMVector.MVector V ty s a) ty where
     mkSEXPIO = return . SMVector.toSEXP
     fromSEXP =
         SMVector.fromSEXP .

--- a/inline-r/tests/Test/Vector.hs
+++ b/inline-r/tests/Test/Vector.hs
@@ -100,7 +100,7 @@ testNumericSEXPVector dummy = testGroup "Test Numeric Vector"
 
 fromListLength :: TestTree
 fromListLength = testCase "fromList should have correct length" $ runRegion $ do
-    _ <- io $ return $ idVec $ V.fromListN 3 [-1.9, -0.1, -2.9]
+    _ <- return $ idVec $ V.fromListN 3 [-1.9, -0.1, -2.9]
     let v = idVec $ V.fromList [-1.9, -0.1, -2.9]
     _ <- io $ R.protect (V.unVector v)
     io $ assertEqual "Length should be equal to list length" 3 (V.length v)
@@ -113,11 +113,10 @@ vectorIsImmutable :: TestTree
 vectorIsImmutable = testCase "fromList should have correct length" $ do
     i <- runRegion $ do
            s <- fmap (R.cast (sing :: R.SSEXPTYPE R.Real)) [r| c(1.0,2.0,3.0) |]
-           io $ do
-              let mutV = VM.fromSEXP s
-              immV <- V.fromSEXP s
-              VM.unsafeWrite mutV 0 7
-              return $ immV V.! 0
+           let mutV = VM.fromSEXP s
+           immV <- V.fromSEXP s
+           VM.unsafeWrite mutV 0 7
+           return $ immV V.! 0
     i @?= 1
 
 tests :: TestTree

--- a/inline-r/tests/test-qq.hs
+++ b/inline-r/tests/test-qq.hs
@@ -115,14 +115,14 @@ main = H.withEmbeddedR H.defaultConfig $ H.runRegion $ do
     _ <- [r| `+` <- base::`+` |]
 
     -- test Vector literal instance
-    v1 <- io $ do
-      x <- SMVector.new 3 :: IO (SMVector.IOVector V 'R.Int Int32)
+    v1 <- do
+      x <- SMVector.new 3 :: R s (SMVector.MVector V 'R.Int s Int32)
       SMVector.unsafeWrite x 0 1
       SMVector.unsafeWrite x 1 2
       SMVector.unsafeWrite x 2 3
       return x
     ("c(7, 2, 3)" @=?) =<< [r| v = v1_hs; v[1] <- 7; v |]
-    io $ assertEqual "" "fromList [1,2,3]" . Prelude.show =<< SVector.unsafeFreeze v1
+    io . assertEqual "" "fromList [1,2,3]" . Prelude.show =<< SVector.unsafeFreeze v1
 
     let utf8string = "abcd çéõßø"
     io . assertEqual "" utf8string =<< fromSEXP <$> R.cast (sing :: R.SSEXPTYPE 'R.String) <$> [r| utf8string_hs |]

--- a/inline-r/tests/tests.hs
+++ b/inline-r/tests/tests.hs
@@ -86,7 +86,7 @@ tests = testGroup "Unit tests"
          y <- R.cast (sing :: R.SSEXPTYPE R.Real) . R.SomeSEXP
                      <$> mkSEXP (42::Double)
          case hexp y of
-           Real s -> io $ basicUnsafeIndexM s 0
+           Real s -> basicUnsafeIndexM s 0
   , Test.Constraints.tests
   , Test.FunPtr.tests
   , Test.HExp.tests

--- a/inline-r/tests/vector.hs
+++ b/inline-r/tests/vector.hs
@@ -113,7 +113,6 @@ fromListLength = testCase "fromList should have correct length" $ runRegion $ do
    let v = idVec $ V.fromList [-1.9,-0.1,-2.9]
    _ <- io $ R.protect (V.unVector v)
    io $ assertEqual "Length should be equal to list length" 3 (V.length v)
-   -- io $ Prelude.print v
    return ()
 
 -- | Helper in order to help ghc infer ty and as types that are
@@ -139,4 +138,3 @@ testFromStorable = testCase "fromStorable should work" $ runRegion $ do
    1 @=? ss V.! 0
    2 @=? ss V.! 1
    3 @=? ss V.! 2
-


### PR DESCRIPTION
This allows the `Data.Vector.SEXP` vector API to be used in the `R`
monad, not just the `IO` monad. This commit also changes the tests to
use `R` mutable operations on vectors, rather than `IO` ones.