### PR TITLE
Fix vector copying

### DIFF
--- a/inline-r/src/Data/Vector/SEXP.chs
+++ b/inline-r/src/Data/Vector/SEXP.chs
@@ -327,15 +327,15 @@ instance (VECTOR s ty a)
   -- directly.
   basicUnsafeSlice i l v         = unsafeInlineIO $ do
     mv <- Mutable.new l
-    copyArray (toVecPtr v `plusPtr` i)
-              (toMVecPtr mv)
+    copyArray (toMVecPtr mv)
+              (toVecPtr v `plusPtr` i)
               l
     G.basicUnsafeFreeze mv
   basicUnsafeIndexM v i          = return . unsafeInlineIO
                                  $ peekElemOff (toVecPtr v) i
   basicUnsafeCopy   mv v         = unsafePrimToPrim $
-    copyArray (toVecPtr v)
-              (toMVecPtr mv)
+    copyArray (toMVecPtr mv)
+              (toVecPtr v)
               (G.basicLength v)
 
   elemseq _                      = seq


### PR DESCRIPTION
This commit fixes bug #204 . I think we may want to add more tests to vector implementation in the near future.