### PR TITLE
Added withRegion.

### DIFF
--- a/inline-r/tests/Test/Regions.hs
+++ b/inline-r/tests/Test/Regions.hs
@@ -80,7 +80,7 @@ tests = testGroup "regions"
           _ <- mkSEXP (1 :: Int32)
           withRegion $ do
             _ <- mkSEXP (1 :: Int32)
-            pure ()
+            return ()
     , testCase "withRegion-deep" $
       preserveDirectory $ assertBalancedStack $
         runRegion $ do

--- a/inline-r/tests/Test/Regions.hs
+++ b/inline-r/tests/Test/Regions.hs
@@ -74,4 +74,20 @@ tests = testGroup "regions"
             _ <- [r| gctorture(FALSE) |]
             return ()
           return (z::Int32)
+    , testCase "withRegion-simple" $
+      preserveDirectory $ assertBalancedStack $
+        runRegion $ do
+          _ <- mkSEXP (1 :: Int32)
+          withRegion $ do
+            _ <- mkSEXP (1 :: Int32)
+            pure ()
+    , testCase "withRegion-deep" $
+      preserveDirectory $ assertBalancedStack $
+        runRegion $ do
+          x <- mkSEXP (1 :: Int32)
+          withRegion $ withRegion $ withRegion $ do
+            y <- mkSEXP (1 :: Int32)
+            let x' = fromSEXP x :: Int32
+                y' = fromSEXP y :: Int32
+            io $ assertEqual "fromSEXP in withRegion" x' y'
     ]


### PR DESCRIPTION
`withRegion` introduces nested regions as we can run a `R q a` action
in `R s a` action with `q <= s`. I made basic test on the nesting
property, even though I haven’t found a way – yet? – to test whether
the resources are correctly freed and released – even though the deepseq
should help to ensure that.