### PR TITLE
OS X CI support via Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,8 @@ install:
   - brew install r zeromq python
   - pip install ipython
   - stack setup
-  - stack --no-terminal -j1 build --only-snapshot --prefetch --test --bench
+  - stack --no-terminal -j2 build --only-snapshot --prefetch --test --bench
 
 script:
   # XXX no tests for now since it times out.
-  - stack --no-terminal -j1 build --pedantic
+  - stack --no-terminal -j2 build --pedantic

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,43 @@
+language: c
+sudo: false
+
+os:
+  - linux
+  - osx
+
+matrix:
+  fast_finish: true
+  allow_failures:
+  - os: osx
+
+services:
+  - docker
+
+cache:
+  directories:
+  - $HOME/.stack
+
+env:
+  - PATH=$HOME/.local/bin:$PATH
+
+# XXX see https://github.com/travis-ci/travis-ci/issues/4709
+before_install:
+  - if [ $TRAVIS_OS_NAME = osx ]; then sudo security delete-certificate -Z 2F173F7DE99667AFA57AF80AA2D1B12FAC830338 /System/Library/Keychains/SystemRootCertificates.keychain; fi
+  - if [ $TRAVIS_OS_NAME = osx ]; then rvm osx-ssl-certs update all; fi
+
+install:
+  # Even though we have stack in docker image, we still need it on CI
+  - curl -LO https://github.com/commercialhaskell/stack/releases/download/v0.1.6.0/stack-0.1.6.0-$TRAVIS_OS_NAME-x86_64.tar.gz
+  - tar xf stack-0.1.6.0-$TRAVIS_OS_NAME-x86_64.tar.gz
+  - mkdir -p ~/.local/bin
+  - cp stack-0.1.6.0-$TRAVIS_OS_NAME-x86_64/stack ~/.local/bin
+  - if [ $TRAVIS_OS_NAME = osx ]; then brew install zeromq && brew update && brew tap homebrew/science && brew install r; fi
+  # should run inside docker container
+  - export STACK_ARGS="--no-terminal"
+  - if [ $TRAVIS_OS_NAME = linux ]; then stack $STACK_ARGS docker pull; fi
+  - if [ $TRAVIS_OS_NAME = linux ]; then export STACK_ARGS="$STACK_ARGS --docker"; fi
+  - stack $STACK_ARGS -j1 build --only-snapshot --prefetch --test --bench
+
+script:
+  - if [ $TRAVIS_OS_NAME = linux ]; then export STACK_ACTIONS="--test --bench --haddock"; fi
+  - stack $STACK_ARGS -j1 build --pedantic --no-haddock-deps $STACK_ACTIONS

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,13 +14,14 @@ env:
 before_install:
   - sudo security delete-certificate -Z 2F173F7DE99667AFA57AF80AA2D1B12FAC830338 /System/Library/Keychains/SystemRootCertificates.keychain
   - rvm osx-ssl-certs update all
+  - mkdir -p ~/.local/bin
+  - travis_retry curl -L https://www.stackage.org/stack/osx-x86_64 | tar xz --strip-components=1 -C ~/.local/bin
 
 install:
-  - curl -LO https://github.com/commercialhaskell/stack/releases/download/v0.1.6.0/stack-0.1.6.0-$TRAVIS_OS_NAME-x86_64.tar.gz
-  - tar xf stack-0.1.6.0-$TRAVIS_OS_NAME-x86_64.tar.gz
-  - mkdir -p ~/.local/bin
-  - cp stack-0.1.6.0-$TRAVIS_OS_NAME-x86_64/stack ~/.local/bin
-  - brew install zeromq && brew update && brew tap homebrew/science && brew install r
+  - brew update
+  - brew tap homebrew/science
+  - brew install r zeromq python
+  - pip install ipython
   - stack setup
   - stack --no-terminal -j1 build --only-snapshot --prefetch --test --bench
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,8 @@
 language: c
-sudo: false
-
 os:
-  - linux
   - osx
 
-matrix:
-  fast_finish: true
-  allow_failures:
-  - os: osx
-
-services:
-  - docker
-
+# XXX Doesn't work on OS X VM's currently (Nov 2015).
 cache:
   directories:
   - $HOME/.stack
@@ -22,22 +12,18 @@ env:
 
 # XXX see https://github.com/travis-ci/travis-ci/issues/4709
 before_install:
-  - if [ $TRAVIS_OS_NAME = osx ]; then sudo security delete-certificate -Z 2F173F7DE99667AFA57AF80AA2D1B12FAC830338 /System/Library/Keychains/SystemRootCertificates.keychain; fi
-  - if [ $TRAVIS_OS_NAME = osx ]; then rvm osx-ssl-certs update all; fi
+  - sudo security delete-certificate -Z 2F173F7DE99667AFA57AF80AA2D1B12FAC830338 /System/Library/Keychains/SystemRootCertificates.keychain
+  - rvm osx-ssl-certs update all
 
 install:
-  # Even though we have stack in docker image, we still need it on CI
   - curl -LO https://github.com/commercialhaskell/stack/releases/download/v0.1.6.0/stack-0.1.6.0-$TRAVIS_OS_NAME-x86_64.tar.gz
   - tar xf stack-0.1.6.0-$TRAVIS_OS_NAME-x86_64.tar.gz
   - mkdir -p ~/.local/bin
   - cp stack-0.1.6.0-$TRAVIS_OS_NAME-x86_64/stack ~/.local/bin
-  - if [ $TRAVIS_OS_NAME = osx ]; then brew install zeromq && brew update && brew tap homebrew/science && brew install r; fi
-  # should run inside docker container
-  - export STACK_ARGS="--no-terminal"
-  - if [ $TRAVIS_OS_NAME = linux ]; then stack $STACK_ARGS docker pull; fi
-  - if [ $TRAVIS_OS_NAME = linux ]; then export STACK_ARGS="$STACK_ARGS --docker"; fi
-  - stack $STACK_ARGS -j1 build --only-snapshot --prefetch --test --bench
+  - brew install zeromq && brew update && brew tap homebrew/science && brew install r
+  - stack setup
+  - stack --no-terminal -j1 build --only-snapshot --prefetch --test --bench
 
 script:
-  - if [ $TRAVIS_OS_NAME = linux ]; then export STACK_ACTIONS="--test --bench --haddock"; fi
-  - stack $STACK_ARGS -j1 build --pedantic --no-haddock-deps $STACK_ACTIONS
+  # XXX no tests for now since it times out.
+  - stack --no-terminal -j1 build --pedantic


### PR DESCRIPTION
We still use CircleCI for Linux testing (for now). Reason: Travis CI
currently makes you choose between docker support and caching support,
when CircleCI does not. For OS X testing we don't have a choice.