### PR TITLE
Remove cbits/hcompat.h

### DIFF
--- a/inline-r/inline-r.cabal
+++ b/inline-r/inline-r.cabal
@@ -16,8 +16,7 @@ description:
 
 cabal-version:       >=1.10
 
-extra-source-files:   cbits/Hcompat.h
-                      cbits/missing_r.h
+extra-source-files:   cbits/missing_r.h
                       tests/shootout/binarytrees.R
                       tests/shootout/fasta.R
                       tests/shootout/knucleotide.R
@@ -86,7 +85,7 @@ library
                      , transformers >= 0.3
                      , vector >= 0.10 && < 0.11
   hs-source-dirs:      src
-  includes:            cbits/Hcompat.h cbits/missing_r.h
+  includes:            cbits/missing_r.h
   c-sources:           cbits/missing_r.c
   include-dirs:        cbits
   default-language:    Haskell2010

--- a/inline-r/src/Foreign/R.chs
+++ b/inline-r/src/Foreign/R.chs
@@ -172,7 +172,6 @@ import Foreign.C
 import Prelude hiding (asTypeOf, length)
 
 #define USE_RINTERNALS
-#include "Hcompat.h"
 #include <R.h>
 #include <Rinternals.h>
 #include <R_ext/Memory.h>

--- a/inline-r/src/Foreign/R/Embedded.chs
+++ b/inline-r/src/Foreign/R/Embedded.chs
@@ -16,7 +16,6 @@ module Foreign.R.Embedded
 import Foreign
 import Foreign.C
 
-#include "Hcompat.h"
 #include <Rembedded.h>
 #include "missing_r.h"
 

--- a/inline-r/src/Foreign/R/Parse.chs
+++ b/inline-r/src/Foreign/R/Parse.chs
@@ -11,8 +11,6 @@
 {-# OPTIONS_GHC -fno-warn-unticked-promoted-constructors #-}
 #endif
 
-#include "Hcompat.h"
-
 #include <Rinternals.h>
 #include <R_ext/Parse.h>
 module Foreign.R.Parse

--- a/inline-r/src/Language/R/HExp.chs
+++ b/inline-r/src/Language/R/HExp.chs
@@ -83,7 +83,6 @@ import Unsafe.Coerce (unsafeCoerce)
 import Prelude
 
 #define USE_RINTERNALS
-#include "Hcompat.h"
 #include <R.h>
 #include <Rinternals.h>
 


### PR DESCRIPTION
This was a compatibility shim necessary under Darwin, because c2hs was
choking on header files. On OS X 10.11, this shim is actively unhelpful,
and in any case newer versions of c2hs don't choke on these files
anymore, so this shim should go.

Fixes #220.

cc @sbacelar @mietek