### PR TITLE
Add support for subregions.

### DIFF
--- a/inline-r/src/Language/R.hs
+++ b/inline-r/src/Language/R.hs
@@ -7,9 +7,12 @@
 {-# LANGUAGE ForeignFunctionInterface #-}
 {-# Language GADTs #-}
 {-# Language ViewPatterns #-}
+{-# Language TypeOperators #-}
 
 module Language.R
-  ( parseFile
+  ( subr
+  , subrSome
+  , parseFile
   , parseText
   , install
   , string
@@ -56,6 +59,16 @@ import Prelude
 
 -- NOTE: In this module, cannot use quasiquotations, since we are lower down in
 -- the dependency hierarchy.
+
+-- | Teleport an object from one memory region to another. This is safe to do
+-- provided the object was allocated in some ancestor region, i.e. a region
+-- whose dynamic extent outlives that of the target region.
+subr :: (s <= s') => SEXP s' a -> SEXP s a
+subr = R.sexp . R.unsexp
+
+-- | Like 'sub' but for 'SomeSEXP'.
+subrSome :: (s <= s') => SomeSEXP s' -> SomeSEXP s
+subrSome sx = SomeSEXP $ R.unSomeSEXP sx (R.sexp . R.unsexp)
 
 -- | Parse and then evaluate expression.
 parseEval :: ByteString -> IO (SomeSEXP V)

--- a/inline-r/tests/Test/Regions.hs
+++ b/inline-r/tests/Test/Regions.hs
@@ -10,6 +10,7 @@ module Test.Regions
 import           Control.Memory.Region
 import qualified Foreign.R as R
 import           H.Prelude
+import           Language.R.HExp (hexp, (===))
 import           Language.R.QQ
 
 import Test.Tasty hiding (defaultMain)
@@ -78,4 +79,12 @@ tests = testGroup "regions"
             return ()
         _ <- [r| gc() |]
         io $ takeMVar mv
+    , testCase "withRegion-parent-region-unaffected" $
+      runRegion $ do
+        R.SomeSEXP x <- [r| 1 |]
+        () <- withRegion $ do
+          R.SomeSEXP y <- [r| 1 |]
+          io $ assert $ hexp (subr x) === hexp y
+        _ <- [r| gc() |]
+        io $ assertEqual "value is protected" R.Real (R.typeOf x)
     ]


### PR DESCRIPTION
Add `withRegion`, `subr` and `subrSome`. All objects allocated during
the dynamic extent of a call to `withRegion` are liable to be freed by
R's garbage collector once the call returns. Since the dynamic extent of
a nested region is smaller than that of its parent region, using
a nested regions allows objects to be freed sooner.
