### PR TITLE
Don't install R signal handlers by default.

### DIFF
--- a/inline-r/src/Foreign/R.chs
+++ b/inline-r/src/Foreign/R.chs
@@ -127,6 +127,7 @@ module Foreign.R
   , baseEnv
   , emptyEnv
   , globalEnv
+  , signalHandlers
     -- * Communication with runtime
   , printValue
     -- * Low level info header access
@@ -173,6 +174,7 @@ import Prelude hiding (asTypeOf, length)
 
 #define USE_RINTERNALS
 #include <R.h>
+#include <Rinterface.h>
 #include <Rinternals.h>
 #include <R_ext/Memory.h>
 #include "missing_r.h"
@@ -578,6 +580,9 @@ foreign import ccall "&R_EmptyEnv" emptyEnv :: Ptr (SEXP G R.Env)
 
 -- | Global environment.
 foreign import ccall "&R_GlobalEnv" globalEnv :: Ptr (SEXP G R.Env)
+
+-- | Signal handler switch
+foreign import ccall "&R_SignalHandlers" signalHandlers :: Ptr CInt
 
 ----------------------------------------------------------------------------------
 -- Structure header                                                             --

--- a/inline-r/src/Language/R/Globals.hs
+++ b/inline-r/src/Language/R/Globals.hs
@@ -19,6 +19,7 @@ module Language.R.Globals
   -- * R Internal constants
   , isRInteractive
   , inputHandlers
+  , signalHandlersPtr
   -- * R global constants
   -- $ghci-bug
   , pokeRVariables
@@ -59,6 +60,7 @@ type RVariables =
     , Ptr (SEXP G 'R.Symbol)
     , Ptr CInt
     , Ptr (Ptr R.InputHandler)
+    , Ptr CInt
     )
 
 -- | Stores R variables in a static location. This makes the variables'
@@ -76,6 +78,7 @@ pokeRVariables = poke rVariables <=< newStablePtr
  , missingArgPtr
  , isRInteractive
  , inputHandlersPtr
+ , signalHandlersPtr
  ) = unsafePerformIO $ peek rVariables >>= deRefStablePtr
 
 -- | Special value to which all symbols unbound in the current environment

--- a/inline-r/src/Language/R/Instance.hs
+++ b/inline-r/src/Language/R/Instance.hs
@@ -239,12 +239,14 @@ initialize Config{..} = do
           , R.missingArg
           , R.isRInteractive
           , R.inputHandlers
+          , R.signalHandlers
           )
         populateEnv
         args <- (:) <$> maybe getProgName return configProgName
                     <*> pure configArgs
         argv <- mapM newCString args
         let argc = length argv
+        poke signalHandlersPtr 0
         newCArray argv $ R.initEmbeddedR argc
         poke isRInteractive 0
         poke isRInitializedPtr 1

--- a/inline-r/src/Language/R/Instance.hs
+++ b/inline-r/src/Language/R/Instance.hs
@@ -143,6 +143,10 @@ data Config = Config
     configProgName :: Maybe String
     -- | Command-line arguments.
   , configArgs :: [String]
+
+    -- | Set to 'True' if you're happy to let R install its own signal handlers
+    -- during initialization.
+  , configSignalHandlers :: Bool
   }
 
 instance Default Config where
@@ -153,11 +157,12 @@ instance Monoid Config where
   mappend cfg1 cfg2 = Config
       { configProgName = configProgName cfg1 <> configProgName cfg2
       , configArgs = configArgs cfg1 <> configArgs cfg2
+      , configSignalHandlers =  configSignalHandlers cfg2
       }
 
 -- | Default argument to pass to 'initialize'.
 defaultConfig :: Config
-defaultConfig = Config Nothing ["--vanilla", "--silent"]
+defaultConfig = Config Nothing ["--vanilla", "--silent"] False
 
 -- | Populate environment with @R_HOME@ variable if it does not exist.
 populateEnv :: IO ()
@@ -200,8 +205,7 @@ initLock = unsafePerformIO $ newMVar ()
 -- main thread of the program. That is, from the same thread of execution that
 -- the program's @main@ function is running on. In GHCi, use @-fno-ghci-sandbox@
 -- to achieve this.
-initialize :: Config
-           -> IO ()
+initialize :: Config -> IO ()
 initialize Config{..} = do
 #ifdef H_ARCH_UNIX
 #ifdef H_ARCH_UNIX_DARWIN
@@ -246,7 +250,8 @@ initialize Config{..} = do
                     <*> pure configArgs
         argv <- mapM newCString args
         let argc = length argv
-        poke signalHandlersPtr 0
+        unless configSignalHandlers $
+          poke signalHandlersPtr 0
         newCArray argv $ R.initEmbeddedR argc
         poke isRInteractive 0
         poke isRInitializedPtr 1


### PR DESCRIPTION
Add a new function `withEmbeddedRHandlers` to install them in case you
need them.

Fixes #224.