### PR TITLE
Use temporary rather than temporary-rc

### DIFF
--- a/H/H.cabal
+++ b/H/H.cabal
@@ -32,7 +32,7 @@ executable H
                      , file-embed >= 0.0.7
                      , pretty >= 1.1
                      , process >= 1.2
-                     , temporary-rc >= 1.2.0.3
+                     , temporary >= 1.2.0.3
                      , vector >= 0.10
   default-language:    Haskell2010
   ghc-options:         -Wall -threaded

--- a/examples/HaskellR-examples.cabal
+++ b/examples/HaskellR-examples.cabal
@@ -24,7 +24,7 @@ executable RelaxWithNM
                      , base >= 4.6 && < 5
                      , deepseq
                      , integration
-                     , temporary-rc >= 1.2.0.3
+                     , temporary >= 1.2.0.3
   default-language:    Haskell2010
   ghc-options:         -Wall -threaded
 


### PR DESCRIPTION
`temporary-rc` has been [deprecated](http://hackage.haskell.org/package/temporary-rc).