### PR TITLE
Fix memory tests

### DIFF
--- a/inline-r/inline-r.cabal
+++ b/inline-r/inline-r.cabal
@@ -124,7 +124,8 @@ test-suite tests
                      , quickcheck-assertions >= 0.1.1
                      , singletons >= 0.10
                      , strict >= 0.3.2
-                     , tasty >= 0.3
+                     , tasty >= 0.11
+                     , tasty-expected-failure >= 0.11
                      , tasty-golden >= 2.3
                      , tasty-hunit >= 0.4.1
                      , tasty-quickcheck >= 0.4.1

--- a/inline-r/tests/Test/GC.hs
+++ b/inline-r/tests/Test/GC.hs
@@ -18,18 +18,21 @@ import System.Directory
 
 import System.Mem (performMajorGC)
 
+-- These tests only work with a version of R compiled
+-- with --enable-strict-barrier.
+
 tests :: TestTree
-tests = testGroup "HVal"
-    [ testCase "Automatic value is not collected by R GC" $
+tests = testGroup "Automatic values"
+    [ testCase "Live automatic not collected by GC" $
       bracket getCurrentDirectory setCurrentDirectory $ const $ do
-        ((assertBool "Automatic value was collected" . isInt) =<<) $ do
-            unsafeRToIO $ do
+        ((assertBool "Automatic value was not collected" . isInt) =<<) $ do
+            runRegion $ do
               x <- automatic =<< io (R.allocVector SingR.SInt 1024 :: IO (R.SEXP V 'R.Int))
               io $ R.gc
               return $ R.typeOf x
-    , testCase "Automatic value works after release" $
+    , testCase "Dead automatic collected by GC" $
       bracket getCurrentDirectory setCurrentDirectory $ const $ do
-        ((assertBool "Automatic value was collected" . isInt) =<<) $ do
+        ((assertBool "Automatic value was collected" . not . isInt) =<<) $ do
            runRegion $ do
               _ <- [r| gctorture(TRUE) |]
               x <- automatic =<< io (R.allocVector SingR.SInt 1024 :: IO (R.SEXP V 'R.Int))

--- a/stack.yaml
+++ b/stack.yaml
@@ -4,6 +4,9 @@ packages:
 - IHaskell
 - inline-r
 resolver: lts-3.13
+extra-deps:
+- tasty-0.11.0.2
+- tasty-expected-failure-0.11.0.3
 
 docker:
   # Disabled by default. Use --docker on command line to enable.


### PR DESCRIPTION
They now pass w/ and wo/ --enable-strict-barrier.

One GC test in particular was actually incorrect, but this was never
caught because without --enable-strict-barrier, we can't properly
observe deallocation events.

So this patch further more *disables* all memory tests entirely if we
don't have --enable-strict-barrier. Since we can't reliably test
deallocation events without it. Since we can't test at runtime
whether --enable-strict-barrier was turned on or not, we instead allow
the user to pass --torture as an argument to the test suite.