### PR TITLE
Rewrite R quasiquoter.

### DIFF
--- a/H/H.ghci
+++ b/H/H.ghci
@@ -11,6 +11,6 @@ import Language.R.HExp as H
 import qualified H.Prelude.Interactive as H
 import Foreign.R as R (SEXP, SomeSEXP(..), SEXPTYPE, SEXPInfo, unSomeSEXP)
 import Language.R as R (R)
-import Language.R.QQ as H (r, rexp, rsafe)
+import Language.R.QQ as H (r, rsafe)
 
 Language.R.Instance.initialize Language.R.Instance.defaultConfig

--- a/H/tests/qq.ghci
+++ b/H/tests/qq.ghci
@@ -1,4 +1,3 @@
-:set -XDataKinds
 :set -XScopedTypeVariables
 :m +Data.Int
 import qualified Foreign.R as R
@@ -14,7 +13,7 @@ H.print =<< [r| 1 + 2 |]
 H.print =<< [r| c(1,2,"3") |] :: IO ()
 
 -- Should be: [1] 2
-H.print =<< [r| x <- 2 |] :: IO ()
+H.print =<< [r| x <<- 2 |] :: IO ()
 
 -- Should be: [1] 3
 H.print =<< [r| x+1 |]
@@ -23,26 +22,25 @@ H.print =<< [r| x+1 |]
 let y = (5::Double)
 H.print =<< [r| y_hs + 1 |]
 
----- Should be: Closure ???
-H.print =<< [r| function(y) y_hs + y |]
+-- Printing of functions gives non deterministic output (env names change).
+--H.print =<< [r| function(y) y_hs + y |]
 
 -- Should be 8
-H.print =<< [r| z <- function(y) y_hs + y |]
-H.print =<< [r| z(3) |]
+H.print =<< [r| z <- function(y) y_hs + y; z(3) |]
 
 -- Should be [1] 1 2 3 4 5 6 7 8 9 10
-H.print =<< [r| y <- c(1:10) |]
+H.print =<< [r| y <<- c(1:10) |]
 let foo1 = (\x -> (return $ x+1 :: R s Double))
 let foo2 = (\x -> (return $ map (+1) x :: R s [Int32]))
 
 -- Should be [1] 2
-H.print =<< [r| (function(x).Call(foo1_hs,x))(2) |]
+H.print =<< [r| mapply(foo1_hs, 2) |]
 
 -- Should be [1] 2 3 4 5 6 7 8 9 10 11
-H.print =<< [r| (function(x).Call(foo2_hs,x))(y) |]
+H.print =<< [r| mapply(foo2_hs, y) |]
 
 -- Should be [1] 43
-H.print =<< [r| x <- 42 ; x + 1 |]
+H.print =<< [r| x <<- 42 ; x + 1 |]
 
 -- Should be [1] 1 2 3
 let xs = [1,2,3]::[Double]
@@ -66,27 +64,16 @@ H.print =<< [r| foo4_hs(33, 66) |]
 let fact n = if n == (0 :: Int32) then (return 1 :: R s Int32) else fmap H.fromSomeSEXP [r| as.integer(n_hs * fact_hs(n_hs - 1L)) |]
 H.print =<< [r| fact_hs(5L) |]
 
-:set -XDataKinds
 -- Should be [1] 29
 let foo5  = (\n -> return (n+1)) :: Int32 -> R s Int32
-let apply = (\n m -> [r| .Call(n_hs, m_hs) |]) :: R.Callback s -> Int32 -> R s (R.SomeSEXP s)
+let apply = (\n m -> [r| n_hs(m_hs) |]) :: R.Callback s -> Int32 -> R s (R.SomeSEXP s)
 H.print =<< [r| apply_hs(foo5_hs, 28L ) |]
 
 sym <- H.install "blah"
 H.print sym
 
--- Should be [1] 100
-_ <- [r| `+` <- function(x,y) x * y |]
-H.print =<< [r| 10 + 10 |]
-
--- Should be [1] 20
-H.print =<< [r| base::`+`(10,10) |]
-
--- restore usual meaning of `+`
-_ <- [r| `+` <- base::`+` |]
-
 :{
-let hFib :: Foreign.R.SEXP s Foreign.R.Int -> H.Prelude.R s (Foreign.R.SEXP s Foreign.R.Int)
+let hFib :: SEXP s 'R.Int -> R s (SEXP s 'R.Int)
     hFib n@(H.fromSEXP -> 0 :: Int32) = fmap (flip R.asTypeOf n) [r| 0L |]
     hFib n@(H.fromSEXP -> 1 :: Int32) = fmap (flip R.asTypeOf n) [r| 1L |]
     hFib n = (`R.asTypeOf` n) <$> [r| hFib_hs(n_hs - 1L) + hFib_hs(n_hs - 2L) |]
@@ -99,7 +86,7 @@ let hFib :: Foreign.R.SEXP s Foreign.R.Int -> H.Prelude.R s (Foreign.R.SEXP s Fo
 -- Create an S4 class
 H.print =<< [r| setClass("x-test",representation(a = "numeric", b = "numeric"), prototype(a=1,b=2)) |]
 -- instantiate and object in R
-H.print =<< [r| x <- new("x-test") |]
+H.print =<< [r| x <<- new("x-test") |]
 -- instantiate and object and pass it to H as-is
 x <- [r| new("x-test") |]
 -- show object

--- a/H/tests/qq.ghci
+++ b/H/tests/qq.ghci
@@ -66,7 +66,7 @@ H.print =<< [r| fact_hs(5L) |]
 
 -- Should be [1] 29
 let foo5  = (\n -> return (n+1)) :: Int32 -> R s Int32
-let apply = (\n m -> [r| n_hs(m_hs) |]) :: R.Callback s -> Int32 -> R s (R.SomeSEXP s)
+let apply = (\n m -> [r| n_hs(m_hs) |]) :: SEXP s 'R.Closure -> Int32 -> R s (R.SomeSEXP s)
 H.print =<< [r| apply_hs(foo5_hs, 28L ) |]
 
 sym <- H.install "blah"

--- a/H/tests/qq.ghci.golden.out
+++ b/H/tests/qq.ghci.golden.out
@@ -4,10 +4,6 @@
 [1] 2
 [1] 3
 [1] 6
-function (y = ) 
-5 + y
-function (y = ) 
-5 + y
 [1] 8
  [1]  1  2  3  4  5  6  7  8  9 10
 [1] 3
@@ -21,8 +17,6 @@ NULL
 [1] 120
 [1] 29
 blah
-[1] 100
-[1] 20
 class generator function for class "x-test" from package '.GlobalEnv'
 function (...) 
 new("x-test", ...)

--- a/examples/nls/nls.H
+++ b/examples/nls/nls.H
@@ -24,7 +24,6 @@ next
 putStrLn $
   unlines [ "Prelare points in R:"
           , "We are creating 'xs' points with R command [r| xs <- c(1:100) |]"
-          , "   [rexp| ... |] creates parsed expression that may be evaluated in GHCi"
           , "   [r| ... |] creates expression and evaluates it"
           , ""
           , "To evaluate command you may use one of the following functions:"
@@ -40,13 +39,11 @@ putStrLn $
           ]
 :}
 next
-putStrLn "printValue [rexp| xs <- c(1:100) |] - expression"
-H.print =<< [rexp| xs <- c(1:100) |]
 putStrLn "printValue $ eval [r| xs <- c(1:100) |] - result"
 H.print =<< [r| xs <- c(1:100) |]
 next
 :{
-putStrLn $ 
+putStrLn $
   unlines [ "Now for each point we want to calculate complicated function"
           , "of cause if example we will use simple example"
           , "But we wil use separate file for it"
@@ -56,7 +53,7 @@ putStrLn $
 :}
 next
 :{
-putStrLn $ 
+putStrLn $
   unlines [ "Now we want to use that function in R:"
           , "in order to use function we need to lift it on vector level"
           ]

--- a/inline-r/cbits/missing_r.h
+++ b/inline-r/cbits/missing_r.h
@@ -7,6 +7,7 @@
 #include <Rinternals.h>
 #include <R_ext/Rdynload.h>
 
+/* Create a variadic R function given any function pointer. */
 SEXP funPtrToSEXP(DL_FUNC pf);
 
 /* Indicates whether R has been initialized. */

--- a/inline-r/inline-r.cabal
+++ b/inline-r/inline-r.cabal
@@ -70,6 +70,7 @@ library
   build-depends:       base >= 4.7 && < 5
                      , aeson >= 0.6
                      , bytestring >= 0.10
+                     , containers >= 0.5
                      , data-default-class
                      , deepseq >= 1.3
                      , exceptions >= 0.6 && < 1.1

--- a/inline-r/src/Foreign/R.chs
+++ b/inline-r/src/Foreign/R.chs
@@ -68,6 +68,7 @@ module Foreign.R
     -- * Node accessor functions
     -- ** Lists
   , cons
+  , lcons
   , car
   , cdr
   , tag
@@ -258,7 +259,7 @@ unSomeSEXP (SomeSEXP s) k = k s
 -- | Foreign functions are represented in R as external pointers. We call these
 -- "callbacks", because they will typically be Haskell functions passed as
 -- arguments to higher-order R functions.
-type Callback s = SEXP s R.ExtPtr
+type Callback s = SEXP s R.Closure
 
 cIntConv :: (Integral a, Integral b) => a -> b
 cIntConv = fromIntegral
@@ -489,6 +490,10 @@ allocVectorProtected ty n = fmap release (protect =<< allocVector ty n)
 
 -- | Allocate a so-called cons cell, in essence a pair of 'SEXP' pointers.
 {#fun Rf_cons as cons { unsexp `SEXP s a', unsexp `SEXP s b' } -> `SEXP V R.List' sexp #}
+
+-- | Allocate a so-called cons cell of language objects, in essence a pair of
+-- 'SEXP' pointers.
+{#fun Rf_lcons as lcons { unsexp `SEXP s a', unsexp `SEXP s b' } -> `SEXP V R.Lang' sexp #}
 
 -- | Print a string representation of a 'SEXP' on the console.
 {#fun Rf_PrintValue as printValue { unsexp `SEXP s a'} -> `()' #}

--- a/inline-r/src/Foreign/R.chs
+++ b/inline-r/src/Foreign/R.chs
@@ -43,7 +43,6 @@ module Foreign.R
   , R.PairList
   , SEXP(..)
   , SomeSEXP(..)
-  , Callback
   , unSomeSEXP
     -- * Casts and coercions
     -- $cast-coerce
@@ -255,11 +254,6 @@ instance NFData (SomeSEXP s) where
 -- existentially quantified variable hidden inside 'SomeSEXP' would escape.
 unSomeSEXP :: SomeSEXP s -> (forall a. SEXP s a -> r) -> r
 unSomeSEXP (SomeSEXP s) k = k s
-
--- | Foreign functions are represented in R as external pointers. We call these
--- "callbacks", because they will typically be Haskell functions passed as
--- arguments to higher-order R functions.
-type Callback s = SEXP s R.Closure
 
 cIntConv :: (Integral a, Integral b) => a -> b
 cIntConv = fromIntegral

--- a/inline-r/src/Language/R/QQ.hs
+++ b/inline-r/src/Language/R/QQ.hs
@@ -80,13 +80,16 @@ parse txt = runIO $ do
     H.initialize H.defaultConfig
     withMVar qqLock $ \_ -> parseText txt False
 
+antiSuffix :: String
+antiSuffix = "_hs"
+
 isAnti :: SEXP s 'R.Char -> Bool
-isAnti (hexp -> Char (Vector.toString -> name)) = "_hs" `isSuffixOf` name
+isAnti (hexp -> Char (Vector.toString -> name)) = antiSuffix `isSuffixOf` name
 isAnti _ = error "Impossible"
 
 -- | Chop antiquotation variable names to get the corresponding Haskell variable name.
 chop :: String -> String
-chop name = take (length name - 3) name
+chop name = take (length name - length antiSuffix) name
 
 -- | Traverse 'R.SEXP' structure and find all occurences of antiquotations.
 collectAntis :: R.SEXP s a -> Set (SEXP s 'R.Char)

--- a/inline-r/src/Language/R/QQ.hs
+++ b/inline-r/src/Language/R/QQ.hs
@@ -15,7 +15,6 @@
 
 module Language.R.QQ
   ( r
-  , rexp
   , rsafe
   ) where
 
@@ -50,15 +49,6 @@ import System.IO.Unsafe (unsafePerformIO)
 r :: QuasiQuoter
 r = QuasiQuoter
     { quoteExp = \txt -> [| eval =<< $(expQQ txt) |]
-    , quotePat  = unimplemented "quotePat"
-    , quoteType = unimplemented "quoteType"
-    , quoteDec  = unimplemented "quoteDec"
-    }
-
--- | Construct an R expression but don't evaluate it.
-rexp :: QuasiQuoter
-rexp = QuasiQuoter
-    { quoteExp  = unimplemented "quoteExp"
     , quotePat  = unimplemented "quotePat"
     , quoteType = unimplemented "quoteType"
     , quoteDec  = unimplemented "quoteDec"

--- a/inline-r/src/Language/R/QQ.hs
+++ b/inline-r/src/Language/R/QQ.hs
@@ -13,8 +13,6 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleContexts #-}
 
-{-# OPTIONS_GHC -fno-warn-orphans #-}
-
 module Language.R.QQ
   ( r
   , rexp
@@ -25,30 +23,23 @@ import           Control.Memory.Region
 import           Control.Monad.R.Class
 import qualified Data.Vector.SEXP as Vector
 import qualified Foreign.R as R
-import qualified Foreign.R.Type as SingR
-import           Foreign.R (SEXP, SomeSEXP(..), SEXPInfo)
+import           Foreign.R (SEXP, SomeSEXP(..))
 import qualified H.Prelude as H
 import           Internal.Error
-import           Language.R (parseText, string, eval)
+import           Language.R (parseText, eval)
 import           Language.R.HExp
 import           Language.R.Instance
-import           Language.R.Literal
-import           Language.R.Internal (installIO)
-
-import qualified Data.ByteString.Char8 as BS
+import           Language.R.Literal (mkSEXPIO)
 
 import Language.Haskell.TH (Q, runIO)
-import Language.Haskell.TH.Lift (deriveLift)
 import Language.Haskell.TH.Quote
 import qualified Language.Haskell.TH.Syntax as TH
 import qualified Language.Haskell.TH.Lib as TH
 
 import Control.Concurrent (MVar, newMVar, withMVar)
-import Control.Monad ((>=>), (<=<))
-import Data.List (isSuffixOf)
-import Data.Complex (Complex)
-import Data.Int (Int32)
-import Data.Word (Word8)
+import Data.List (intercalate, isSuffixOf)
+import qualified Data.Set as Set
+import Data.Set (Set)
 import System.IO.Unsafe (unsafePerformIO)
 
 -------------------------------------------------------------------------------
@@ -58,7 +49,7 @@ import System.IO.Unsafe (unsafePerformIO)
 -- | An R value, expressed as an R expression, in R's syntax.
 r :: QuasiQuoter
 r = QuasiQuoter
-    { quoteExp  = \txt -> parseEval txt
+    { quoteExp = \txt -> [| eval =<< $(expQQ txt) |]
     , quotePat  = unimplemented "quotePat"
     , quoteType = unimplemented "quoteType"
     , quoteDec  = unimplemented "quoteDec"
@@ -67,7 +58,7 @@ r = QuasiQuoter
 -- | Construct an R expression but don't evaluate it.
 rexp :: QuasiQuoter
 rexp = QuasiQuoter
-    { quoteExp  = \txt -> [| io $(parseExp txt) |]
+    { quoteExp  = unimplemented "quoteExp"
     , quotePat  = unimplemented "quotePat"
     , quoteType = unimplemented "quoteType"
     , quoteDec  = unimplemented "quoteDec"
@@ -82,30 +73,11 @@ rexp = QuasiQuoter
 -- TODO some of the above invariants can be checked statically. Do so.
 rsafe :: QuasiQuoter
 rsafe = QuasiQuoter
-    { quoteExp  = \txt -> [| unsafePerformIO $ unsafeRToIO . eval =<< $(parseExp txt) |]
+    { quoteExp  = \txt -> [| unsafePerformIO $ unsafeRToIO . eval =<< $(expQQ txt) |]
     , quotePat  = unimplemented "quotePat"
     , quoteType = unimplemented "quoteType"
     , quoteDec  = unimplemented "quoteDec"
     }
-
-parseEval :: String -> Q TH.Exp
-parseEval txt = do
-    sexp <- parse txt
-    case hexp sexp of
-      Expr _ v ->
-        let vs = Vector.toList v
-        in [| acquireSome <=< io $ $(go vs) |]
-  where
-    go :: [SomeSEXP s] -> Q TH.Exp
-    go []     = error "Impossible happen."
-    go [SomeSEXP (returnIO -> a)]    = [| R.withProtected a (unsafeRToIO . eval) |]
-    go (SomeSEXP (returnIO -> a) : as) =
-        [| R.withProtected a $ unsafeRToIO . eval >=> \(SomeSEXP s) ->
-             R.withProtected (return s) (const $(go as))
-         |]
-
-returnIO :: a -> IO a
-returnIO = return
 
 -- | Serialize quasiquotes using a global lock, because the compiler is allowed
 -- in theory to run them in parallel, yet the R runtime is not reentrant.
@@ -118,199 +90,63 @@ parse txt = runIO $ do
     H.initialize H.defaultConfig
     withMVar qqLock $ \_ -> parseText txt False
 
-parseExp :: String -> Q TH.Exp
-parseExp txt = TH.lift . returnIO =<< parse txt
+isAnti :: SEXP s 'R.Char -> Bool
+isAnti (hexp -> Char (Vector.toString -> name)) = "_hs" `isSuffixOf` name
+isAnti _ = error "Impossible"
 
--- XXX Orphan instance defined here due to bad interaction betwen TH and c2hs.
-instance TH.Lift (IO (SomeSEXP s)) where
-  lift = runIO >=> \s -> R.unSomeSEXP s (TH.lift . returnIO)
+-- | Chop antiquotation variable names to get the corresponding Haskell variable name.
+chop :: String -> String
+chop name = take (length name - 3) name
 
-deriveLift ''SEXPInfo
-deriveLift ''Complex
-deriveLift ''R.Logical
+-- | Traverse 'R.SEXP' structure and find all occurences of antiquotations.
+collectAntis :: R.SEXP s a -> Set (SEXP s 'R.Char)
+collectAntis (hexp -> Symbol name _ _)
+  | isAnti name = Set.singleton name
+collectAntis (hexp -> (List sxa sxb sxc)) = do
+    Set.unions [collectAntis sxa, collectAntis sxb, collectAntis sxc]
+collectAntis (hexp -> (Lang (hexp -> Symbol name _ _) sxb))
+  | isAnti name = Set.insert name (collectAntis sxb)
+collectAntis (hexp -> (Lang sxa sxb)) =
+    Set.union (collectAntis sxa) (collectAntis sxb)
+collectAntis (hexp -> (Closure sxa sxb sxc)) =
+    Set.unions [collectAntis sxa, collectAntis sxb, collectAntis sxc]
+collectAntis (hexp -> (Vector _ sxv)) =
+    Set.unions [collectAntis sx | SomeSEXP sx <- Vector.toList sxv]
+collectAntis (hexp -> (Expr _ sxv)) =
+    Set.unions [collectAntis sx | SomeSEXP sx <- Vector.toList sxv]
+collectAntis _ = Set.empty
 
-instance TH.Lift (IO [SEXP s a]) where
-    lift = runIO >=> go
-      where
-        go []                       = [| return [] |]
-        go [returnIO -> xio]        = [| xio >>= return . (:[]) |]
-        go ((returnIO -> xio) : xs) =
-          [| R.withProtected xio $ $(go xs) . fmap . (:) |]
-
-instance TH.Lift BS.ByteString where
-    lift bs = let s = BS.unpack bs in [| BS.pack s |]
-
-#if ! MIN_VERSION_th_orphans(0,11,0)
-instance TH.Lift Int32 where
-  lift x = let x' = fromIntegral x :: Integer in [| fromInteger x' :: Int32 |]
-
-instance TH.Lift Word8 where
-   lift x = let x' = fromIntegral x :: Integer in [| fromInteger x' :: Word8 |]
-
-instance TH.Lift Double where
-   lift x = [| $(return $ TH.LitE $ TH.RationalL $ toRational x) :: Double |]
-#endif
-
-instance TH.Lift (IO (Vector.Vector s 'R.Raw Word8)) where
-    -- Apparently R considers 'allocVector' to be "defunct" for the CHARSXP
-    -- type. So we have to use some bespoke function.
-    lift = runIO >=> \v -> do
-      let xs :: String
-          xs = map (toEnum . fromIntegral) $ Vector.toList v
-      [| fmap vector $ string xs |]
-
-instance TH.Lift (IO (Vector.Vector s 'R.Char Word8)) where
-    -- Apparently R considers 'allocVector' to be "defunct" for the CHARSXP
-    -- type. So we have to use some bespoke function.
-    lift = runIO >=> \ v -> do
-      let xs :: String
-          xs = map (toEnum . fromIntegral) $ Vector.toList v
-      [| fmap vector $ string xs |]
-
-instance TH.Lift (IO (Vector.Vector s 'R.Logical R.Logical)) where
-    lift = runIO >=> \v -> do
-      let xs = Vector.toList v
-      [| fmap vector $ mkSEXPVectorIO SingR.SLogical $ map return xs |]
-
-instance TH.Lift (IO (Vector.Vector s 'R.Int Int32)) where
-    lift = runIO >=> \v -> do
-      let xs = Vector.toList v
-      [| fmap vector $ mkSEXPVectorIO SingR.SInt $ map return xs |]
-
-instance TH.Lift (IO (Vector.Vector s 'R.Real Double)) where
-    lift = runIO >=> \v -> do
-      let xs = Vector.toList v
-      [| fmap vector $ mkSEXPVectorIO SingR.SReal $ map return xs |]
-
-instance TH.Lift (IO (Vector.Vector s 'R.Complex (Complex Double))) where
-    lift = runIO >=> \v -> do
-      let xs = Vector.toList v
-      [| fmap vector $ mkSEXPVectorIO SingR.SComplex $ map return xs |]
-
-instance TH.Lift (IO (Vector.Vector s 'R.String (SEXP s 'R.Char))) where
-    lift = runIO >=> \v -> do
-      let xsio = returnIO $ Vector.toList v
-      [| fmap vector . mkProtectedSEXPVectorIO SingR.SString =<< xsio |]
-
-instance TH.Lift (IO (Vector.Vector s 'R.Vector (SomeSEXP s))) where
-    lift = runIO >=> \v -> do
-      let xsio = returnIO $ map (\(SomeSEXP s) -> R.unsafeCoerce s)
-                          $ Vector.toList v :: IO [SEXP s 'R.Any]
-      [| fmap vector $ mkProtectedSEXPVectorIO SingR.SVector =<< xsio |]
-
-instance TH.Lift (IO (Vector.Vector s 'R.Expr (SomeSEXP s))) where
-    lift = runIO >=> \v -> do
-      let xsio = returnIO $ map (\(SomeSEXP s) -> R.unsafeCoerce s)
-                          $ Vector.toList v :: IO [SEXP s 'R.Any]
-      [| fmap vector . mkProtectedSEXPVectorIO SingR.SExpr =<< xsio |]
-
--- | Returns 'True' if the variable name is in fact a Haskell value splice.
-isSplice :: String -> Bool
-isSplice = ("_hs" `isSuffixOf`)
-
--- | Chop a splice variable in order to obtain the name of the haskell variable
--- to splice.
-spliceNameChop :: String -> String
-spliceNameChop name = take (length name - 3) name
-
-instance TH.Lift (IO (SEXP s a)) where
-    -- Special case some forms, rather than relying on the default code
-    -- generated by 'deriveLift'.
-    lift = runIO >=> \case
-      (hexp -> Symbol pname _ s) | not (hexp s === Nil) -> [| installIO xs |]
-        where
-          xs :: String
-          xs = map (toEnum . fromIntegral) $ Vector.toList $ vector pname
-      (hexp -> List s (hexp -> Nil) (hexp -> Nil))
-        | R.unsexp s == R.unsexp H.missingArg ->
-          [| R.cons H.missingArg H.nilValue |]
-      s@(hexp -> Symbol (returnIO -> pnameio) value _)
-        | R.unsexp s == R.unsexp value -> [| selfSymbol =<< pnameio |] -- FIXME
-      (hexp -> Symbol pname _ (hexp -> Nil))
-        | Char (Vector.toString -> name) <- hexp pname
-        , isSplice name -> do
-          let hvar = TH.varE $ TH.mkName $ spliceNameChop name
-          [| H.mkSEXPIO $hvar |]
-        | otherwise -> [| installIO xs |]        -- FIXME
-       where
-        xs :: String
-        xs = map (toEnum . fromIntegral) $ Vector.toList $ vector pname
-      (hexp -> Lang (hexp -> Symbol pname _ (hexp -> Nil)) (returnIO -> randsio))
-        | Char (Vector.toString -> name) <- hexp pname
-        , isSplice name -> do
-          let nm = spliceNameChop name
-          hvar <- fmap (TH.varE . (maybe (TH.mkName nm) id)) (TH.lookupValueName nm)
-          [| R.withProtected (installIO ".Call") $ \call ->
-             R.withProtected (H.mkSEXPIO $hvar) $ \f -> do
-                rands <- randsio
-                unhexpIO . Lang call =<< unhexpIO . List f rands =<< unhexpIO Nil
-           |]
-    -- Override the default for expressions because the default Lift instance
-    -- for vectors will allocate a node of VECSXP type, when the node is real an
-    -- EXPRSXP.
-      (hexp -> Expr n v) ->
-        let xsio = returnIO $ map (\(SomeSEXP s) -> R.unsafeCoerce s)
-                            $ Vector.toList v :: IO [SEXP s 'R.Any]
-         in [| R.withProtected (mkProtectedSEXPVectorIO SingR.SExpr =<< xsio) $
-                 unhexpIO . Expr n . vector
-             |]
-      (returnIO . hexp -> iot) ->
-        [| unhexpIO =<< iot |]
-
-instance TH.Lift (IO (HExp s a)) where
-  lift = runIO >=> \case
-    Nil -> [| return Nil |]
-    Symbol (returnIO -> x0io) (returnIO -> x1io) (returnIO -> x2io) ->
-      [| R.withProtected x0io $ \x0 ->
-         R.withProtected x1io $ \x1 ->
-           fmap (Symbol x0 x1) x2io
-        |]
-    List (returnIO -> x0io) (returnIO -> x1io) (returnIO -> x2io) ->
-      [| R.withProtected x0io $ \x0 ->
-         R.withProtected x1io $ \x1 ->
-           fmap (List x0 x1) x2io
-        |]
-    Env (returnIO -> x0io) (returnIO -> x1io) (returnIO -> x2io) ->
-      [| R.withProtected x0io $ \x0 ->
-         R.withProtected x1io $ \x1 ->
-           fmap (Env x0 x1) x2io
-        |]
-    Closure (returnIO -> x0io) (returnIO -> x1io) (returnIO -> x2io) ->
-      [| R.withProtected x0io $ \x0 ->
-         R.withProtected x1io $ \x1 ->
-           fmap (Closure x0 x1) x2io
-        |]
-    Promise (returnIO -> x0io) (returnIO -> x1io) (returnIO -> x2io) ->
-      [| R.withProtected x0io $ \x0 ->
-         R.withProtected x1io $ \x1 ->
-           fmap (Promise x0 x1) x2io
-        |]
-    Lang (returnIO -> x0io) (returnIO -> x1io) ->
-      [| R.withProtected x0io $ \x0 ->
-           fmap (Lang x0) x1io
-        |]
-    Special                  x0  -> [| return $ Special x0 |]
-    Builtin                  x0  -> [| return $ Builtin x0 |]
-    Char      (returnIO -> x0io) -> [| fmap Char      x0io |]
-    Logical   (returnIO -> x0io) -> [| fmap Logical   x0io |]
-    Int       (returnIO -> x0io) -> [| fmap Int       x0io |]
-    Real      (returnIO -> x0io) -> [| fmap Real      x0io |]
-    Complex   (returnIO -> x0io) -> [| fmap Complex   x0io |]
-    String    (returnIO -> x0io) -> [| fmap String    x0io |]
-    DotDotDot (returnIO -> x0io) -> [| fmap DotDotDot x0io |]
-    Vector x0 (returnIO -> x1io) -> [| fmap (Vector x0) x1io |]
-    Expr   x0 (returnIO -> x1io) -> [| fmap (Expr x0) x1io |]
-    Bytecode -> [| return Bytecode |]
-    ExtPtr _ _ _ -> violation "TH.Lift.lift HExp" "Attempted to lift an ExtPtr."
-    WeakRef (returnIO -> x0io) (returnIO -> x1io)
-            (returnIO -> x2io) (returnIO -> x3io) ->
-      [| R.withProtected x0io $ \x0 ->
-         R.withProtected x1io $ \x1 ->
-         R.withProtected x2io $ \x2 ->
-           fmap (WeakRef x0 x1 x2) x3io
-        |]
-    Raw (returnIO -> x0io) -> [| fmap Raw x0io |]
-    S4  (returnIO -> x0io) -> [| fmap S4  x0io |]
-
-unhexpIO :: HExp s a -> IO (SEXP s a)
-unhexpIO = unsafeRToIO . unhexp
+-- | An R quasiquote is syntactic sugar for a function that we
+-- generate, which closes over all antiquotation variables, and applies the
+-- function to the Haskell values to which those variables are bound. Example:
+--
+-- @
+-- [r| x_hs + y_hs |] ==> apply (apply [r| function(x_hs, y_hs) x_hs + y_hs |] x) y
+-- @
+expQQ :: String -> Q TH.Exp
+expQQ input = do
+    expr <- parse input
+    let antis = [x | (hexp -> Char (Vector.toString -> x))
+                       <- Set.toList (collectAntis expr)]
+        args = map (TH.dyn . chop) antis
+        closure = "function(" ++ intercalate "," antis ++ "){" ++ input ++ "}"
+        z = [| return (R.release H.nilValue) |]
+    vars <- mapM (\_ -> TH.newName "x") antis
+    -- Abstract over antis using fresh vars, to avoid captures with names bound
+    -- internally (such as 'f' below).
+    (\body -> foldl TH.appE body args) $ TH.lamE (map TH.varP vars)
+      [| do -- Memoize the runtime parsing of the generated closure (provided the
+            -- compiler notices that it can let-float to top-level).
+            let sx = unsafePerformIO $ do
+                       exprs <- parseText closure False
+                       SomeSEXP e <- R.indexVector exprs 0
+                       clos <- R.eval e (R.release H.globalEnv)
+                       R.unSomeSEXP clos R.preserveObject
+                       return clos
+            io $ case sx of
+              SomeSEXP f ->
+                R.lcons f =<<
+                  $(foldr (\x xs -> [| R.withProtected $xs $ \cdr -> do
+                                         car <- mkSEXPIO $(TH.varE x)
+                                         R.lcons car cdr |]) z vars)
+       |]

--- a/inline-r/tests/test-qq.hs
+++ b/inline-r/tests/test-qq.hs
@@ -97,7 +97,8 @@ main = H.withEmbeddedR H.defaultConfig $ H.runRegion $ do
     ("120L" @=?) =<< [r| fact_hs(5L) |]
 
     let foo5  = \(n :: Int32) -> return (n+1) :: R s Int32
-    let apply = \(n :: R.Callback s) (m :: Int32) -> [r| n_hs(m_hs) |] :: R s (R.SomeSEXP s)
+    let apply :: R.SEXP s 'R.Closure -> Int32 -> R s (R.SomeSEXP s)
+        apply n m = [r| n_hs(m_hs) |]
     ("29L" @=?) =<< [r| apply_hs(foo5_hs, 28L ) |]
 
     sym <- H.install "blah"

--- a/inline-r/tests/test-qq.hs
+++ b/inline-r/tests/test-qq.hs
@@ -58,28 +58,26 @@ main = H.withEmbeddedR H.defaultConfig $ H.runRegion $ do
 
     ("c(\"1\", \"2\", \"3\")" @=?) =<< [r| c(1,2,"3") |]
 
-    ("2" @=?) =<< [r| x <- 2 |]
+    ("2" @=?) =<< [r| x <<- 2 |]
 
     ("3" @=?) =<< [r| x+1 |]
 
     let y = (5::Double)
     ("6" @=?) =<< [r| y_hs + 1 |]
 
-    ("function (y = ) 5 + y" @=?) =<< [r| function(y) y_hs + y |]
-
-    _ <- [r| z <- function(y) y_hs + y |]
+    _ <- [r| z <<- function(y) y_hs + y |]
     ("8" @=?) =<< [r| z(3) |]
 
-    ("1:10" @=?) =<< [r| y <- c(1:10) |]
+    ("1:10" @=?) =<< [r| y <<- c(1:10) |]
 
     let foo1 = (\x -> (return $ x+1 :: R s Double))
     let foo2 = (\x -> (return $ map (+1) x :: R s [Int32]))
 
-    ("3" @=?) =<< [r| (function(x).Call(foo1_hs,x))(2) |]
+    ("3" @=?) =<< [r| mapply(foo1_hs, 2) |]
 
-    ("2:11" @=?) =<< [r| (function(x).Call(foo2_hs,x))(y) |]
+    ("2:11" @=?) =<< [r| mapply(foo2_hs, y) |]
 
-    ("43" @=?) =<< [r| x <- 42 ; x + 1 |]
+    ("43" @=?) =<< [r| x <<- 42 ; x + 1 |]
 
     let xs = [1,2,3]::[Double]
     ("c(1, 2, 3)" @=?) =<< [r| xs_hs |]
@@ -99,19 +97,11 @@ main = H.withEmbeddedR H.defaultConfig $ H.runRegion $ do
     ("120L" @=?) =<< [r| fact_hs(5L) |]
 
     let foo5  = \(n :: Int32) -> return (n+1) :: R s Int32
-    let apply = \(n :: R.Callback s) (m :: Int32) -> [r| .Call(n_hs, m_hs) |] :: R s (R.SomeSEXP s)
+    let apply = \(n :: R.Callback s) (m :: Int32) -> [r| n_hs(m_hs) |] :: R s (R.SomeSEXP s)
     ("29L" @=?) =<< [r| apply_hs(foo5_hs, 28L ) |]
 
     sym <- H.install "blah"
     ("blah" @=?) sym
-
-    _ <- [r| `+` <- function(x,y) x * y |]
-    ("100" @=?) =<< [r| 10 + 10 |]
-
-    ("20" @=?) =<< [r| base::`+`(10,10) |]
-
-    -- restore usual meaning of `+`
-    _ <- [r| `+` <- base::`+` |]
 
     -- test Vector literal instance
     v1 <- do


### PR DESCRIPTION
The new quasiquoter follows an idea from @valderman (Anton Ekblad) for
expanding quasiquotations for higher-order languages: desugar them into
a function F in the object language, which closes over all antiquotation
variables. This approach results in much faster compile times compared
to what we were doing previously: to reconstruct at runtime the R AST
that was observed at quasiquote expansion time (i.e. compile time).

So we expand the quasiquotation into a specially crafted string,
representing F, to be parsed at runtime. This in the end isn't any
slower than evaluating code that reconstructs the AST without parsing,
because parsing the representation of F can be memoized via lazy
evaluation.

A no less important side benefit of this PR, is that we can now handle
antiquotations of higher-order values in any context, not just in
a function application context. This makes antiquoting functions into
R code much more user friendly, and less confusing. Concretely, the
following now works:

```
[r| f_hs(1) |]  -- worked previously
[r| f <- f_hs; f(1) |] -- did not work previously
[r| lapply(c(1,2,3), function(x)f_hs(x)) |] -- worked previously
[r| lapply(c(1,2,3), f_hs) |] -- did not work previously
```

One consequence of this patch is that assignments no longer have global
scope. This is a feature: it protects pure quasiquotes against the
effects of R's late binding. To get the same effect as before one has to
use the `<<-` operator. Which unlike `<-`, will conveniently fail if you
try to redefine a "locked" binding, which applies to all functions
defined in a package somewhere. So even `<<-` can't compromise
referential transparency when `.GlobalEnv` is not used.

Supersedes #188.