### PR TITLE
Rewrite of SEXP vector implementation.

### DIFF
--- a/inline-r/inline-r.cabal
+++ b/inline-r/inline-r.cabal
@@ -66,6 +66,7 @@ library
                        Language.R.QQ
                        Control.Memory.Region
   other-modules:       Control.Monad.R.Class
+                       Control.Monad.R.Internal
                        Internal.Error
   build-depends:       base >= 4.7 && < 5
                      , aeson >= 0.6

--- a/inline-r/inline-r.cabal
+++ b/inline-r/inline-r.cabal
@@ -43,6 +43,7 @@ library
   exposed-modules:     Data.Vector.SEXP
                        Data.Vector.SEXP.Base
                        Data.Vector.SEXP.Mutable
+                       Data.Vector.SEXP.Mutable.Internal
                        Foreign.R
                        Foreign.R.Constraints
                        Foreign.R.Embedded
@@ -79,6 +80,7 @@ library
                      , pretty >= 1.1
                      , primitive >= 0.5
                      , process >= 1.2
+                     , reflection >= 2
                      , setenv >= 0.1.1
                      , singletons >= 0.9
                      , template-haskell >= 2.8

--- a/inline-r/src/Control/Monad/R/Class.hs
+++ b/inline-r/src/Control/Monad/R/Class.hs
@@ -36,6 +36,11 @@ class (Applicative m, MonadIO m, MonadCatch m, MonadMask m, PrimMonad m)
   default acquire :: (MonadIO m, Region m ~ G) => SEXP s a -> m (SEXP G a)
   acquire = liftIO . protect
 
+  -- | Provides no static guarantees that resources do not extrude the scope of
+  -- their region. Acquired resources are not freed automatically upon exit.
+  -- For internal use only.
+  unsafeToIO :: m a -> IO a
+
 type Region m = PrimState m
 
 -- | 'acquire' for 'SomeSEXP'.

--- a/inline-r/src/Control/Monad/R/Class.hs
+++ b/inline-r/src/Control/Monad/R/Class.hs
@@ -36,10 +36,16 @@ class (Applicative m, MonadIO m, MonadCatch m, MonadMask m, PrimMonad m)
   default acquire :: (MonadIO m, Region m ~ G) => SEXP s a -> m (SEXP G a)
   acquire = liftIO . protect
 
+  -- | A reification of an R execution context, i.e. a "session".
+  data ExecContext m :: *
+
+  -- | Get the current execution context.
+  getExecContext :: m (ExecContext m)
+
   -- | Provides no static guarantees that resources do not extrude the scope of
   -- their region. Acquired resources are not freed automatically upon exit.
   -- For internal use only.
-  unsafeToIO :: m a -> IO a
+  unsafeRunWithExecContext :: m a -> ExecContext m -> IO a
 
 type Region m = PrimState m
 

--- a/inline-r/src/Control/Monad/R/Internal.hs
+++ b/inline-r/src/Control/Monad/R/Internal.hs
@@ -1,0 +1,26 @@
+-- |
+-- Copyright: (C) 2016 Tweag I/O Limited.
+
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Control.Monad.R.Internal where
+
+import Control.Memory.Region
+import Control.Monad.R.Class
+import Data.Proxy (Proxy(..))
+import Data.Reflection (Reifies, reify)
+import Foreign.R (SEXP)
+
+newtype AcquireIO s = AcquireIO (forall ty. SEXP V ty -> IO (SEXP s ty))
+
+withAcquire
+  :: forall m r.
+     (MonadR m)
+  => (forall s. Reifies s (AcquireIO (Region m)) => Proxy s -> m r)
+  -> m r
+withAcquire f = reify (AcquireIO (unsafeToIO . macquire)) f
+  where
+    macquire :: SEXP V a -> m (SEXP (Region m) a)
+    macquire = acquire

--- a/inline-r/src/Control/Monad/R/Internal.hs
+++ b/inline-r/src/Control/Monad/R/Internal.hs
@@ -20,7 +20,6 @@ withAcquire
      (MonadR m)
   => (forall s. Reifies s (AcquireIO (Region m)) => Proxy s -> m r)
   -> m r
-withAcquire f = reify (AcquireIO (unsafeToIO . macquire)) f
-  where
-    macquire :: SEXP V a -> m (SEXP (Region m) a)
-    macquire = acquire
+withAcquire f = do
+    cxt <- getExecContext
+    reify (AcquireIO (\sx -> unsafeRunWithExecContext (acquire sx) cxt)) f

--- a/inline-r/src/Data/Vector/SEXP.chs
+++ b/inline-r/src/Data/Vector/SEXP.chs
@@ -280,7 +280,6 @@ import qualified Data.ByteString as B
 import Control.Applicative ((<$>))
 import Control.Monad.Primitive ( unsafeInlineIO, unsafePrimToPrim )
 import Data.Word ( Word8 )
--- import Data.Int  ( Int32 )
 import Foreign ( Ptr, plusPtr, castPtr, peekElemOff )
 import Foreign.ForeignPtr (ForeignPtr, withForeignPtr)
 import Foreign.Marshal.Array ( copyArray )
@@ -300,20 +299,13 @@ import Prelude
   , Ord(..)
   , Show(..)
   , Bool
-  , Int
   , IO
   , Maybe
   , Ordering
   , String
   , (.)
   , ($)
-  , ($!)
-  , (=<<)
-  , all
-  , and
-  , any
   , fromIntegral
-  , or
   , seq
   , uncurry
   )

--- a/inline-r/src/Data/Vector/SEXP.chs
+++ b/inline-r/src/Data/Vector/SEXP.chs
@@ -20,11 +20,16 @@
 
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE ViewPatterns #-}
 
 module Data.Vector.SEXP
   ( Vector(..)
@@ -35,7 +40,6 @@ module Data.Vector.SEXP
   , unsafeFromSEXP
   , Data.Vector.SEXP.toSEXP
   , unsafeToSEXP
-
   -- * Accessors
   -- ** Length information
   , length
@@ -78,7 +82,7 @@ module Data.Vector.SEXP
   -- ** Monadic initialisation
   , replicateM
   , generateM
-  , create
+  -- , create
   -- ** Unfolding
   , unfoldr
   , unfoldrN
@@ -101,25 +105,31 @@ module Data.Vector.SEXP
   -- * Modifying vectors
 
   -- ** Bulk updates
-  , (//) -- , update_,
-  -- unsafeUpd, unsafeUpdate_
+  , (//)
+  -- , update_
+  , unsafeUpd
+  -- , unsafeUpdate_
 
   -- ** Accumulations
-  , accum{-, accumulate_-}
-  , unsafeAccum{-, unsafeAccumulate_-}
+  , accum
+  --, accumulate_
+  , unsafeAccum
+  --, unsafeAccumulate_
 
   -- ** Permutations
-  , reverse{-, backpermute-}{-, unsafeBackpermute -}
+  , reverse
+  --, backpermute
+  --, unsafeBackpermute
 
   -- ** Safe destructive updates
-  {-, modify-}
+  --, modify
 
   -- * Elementwise operations
 
   -- ** Mapping
   , map
   , imap
-  , concatMap
+  -- , concatMap
 
   -- ** Monadic mapping
   , mapM
@@ -140,7 +150,8 @@ module Data.Vector.SEXP
   , izipWith6
 
   -- ** Monadic zipping
-  {-, zipWithM-}, zipWithM_
+  --, zipWithM
+  --, zipWithM_
 
   -- * Working with predicates
 
@@ -162,7 +173,9 @@ module Data.Vector.SEXP
   , notElem
   , find
   , findIndex
-  , {-findIndices,-} elemIndex {-, elemIndices -}
+  --, findIndices
+  , elemIndex 
+  --, elemIndices
 
   -- * Folding
   , foldl
@@ -179,10 +192,12 @@ module Data.Vector.SEXP
   , ifoldr'
 
   -- ** Specialised folds
+  {-
   , all
   , any
   , and
   , or
+  -}
   , sum
   , product
   , maximum
@@ -235,42 +250,47 @@ module Data.Vector.SEXP
   , unsafeThaw
   , unsafeCopy
 
-  -- ** SEXP specific
+  -- ** SEXP specific helpers.
   , toString
   , toByteString
-  , fromStorable
-  , unsafeToStorable
   ) where
 
+import Control.Monad.R.Class
+import Control.Monad.R.Internal
+import Control.Memory.Region
 import Data.Vector.SEXP.Base
-import Data.Vector.SEXP.Mutable (MVector(..))
+import Data.Vector.SEXP.Mutable (MVector)
 import qualified Data.Vector.SEXP.Mutable as Mutable
-import Foreign.R ( SEXP )
+import qualified Data.Vector.SEXP.Mutable.Internal as Mutable
+import Foreign.R ( SEXP(..) )
 import qualified Foreign.R as R
 import Foreign.R.Type ( SEXPTYPE(Char) )
 
-import Control.Monad.Primitive ( PrimMonad, PrimState )
-import Control.Monad.ST (ST)
+import Control.Monad.Primitive ( PrimMonad )
+import Control.Monad.ST (runST)
+import Data.Int
+import Data.Proxy (Proxy(..))
+import Data.Reflection (Reifies(..), reify)
 import qualified Data.Vector.Generic as G
+import Data.Vector.Generic.New (run)
 import qualified Data.Vector.Fusion.Stream as Stream
-import qualified Data.Vector.Storable as Storable
 import Data.ByteString ( ByteString )
-import qualified Data.ByteString.Unsafe as B
+import qualified Data.ByteString as B
 
 import Control.Applicative ((<$>))
-import Control.Monad ( liftM )
 import Control.Monad.Primitive ( unsafeInlineIO, unsafePrimToPrim )
 import Data.Word ( Word8 )
 -- import Data.Int  ( Int32 )
-import Foreign ( Ptr, plusPtr, castPtr )
-import Foreign.C
-import Foreign.Storable
+import Foreign ( Ptr, plusPtr, castPtr, peekElemOff )
+import Foreign.ForeignPtr (ForeignPtr, withForeignPtr)
 import Foreign.Marshal.Array ( copyArray )
 import qualified GHC.Foreign as GHC
+import qualified GHC.ForeignPtr as GHC
 import GHC.IO.Encoding.UTF8
 #if __GLASGOW_HASKELL__ >= 708
 import qualified GHC.Exts as Exts
 #endif
+import System.IO.Unsafe
 
 import Prelude
   ( Eq(..)
@@ -303,12 +323,42 @@ import qualified Prelude
 #define USE_RINTERNALS
 #include <Rinternals.h>
 
+newtype ForeignSEXP (ty::SEXPTYPE) = ForeignSEXP (ForeignPtr ())
+
+-- | Create a 'ForeignSEXP' from 'SEXP'.
+foreignSEXP :: PrimMonad m => SEXP s ty -> m (ForeignSEXP ty)
+foreignSEXP sx@(SEXP ptr) =
+    unsafePrimToPrim $ do
+      R.preserveObject sx
+      ForeignSEXP <$> GHC.newConcForeignPtr (castPtr ptr) (R.releaseObject sx)
+
+{-
+-- | 'ForeignSEXP' deconstructor. Like with 'withForeignPtr' it's not safe to use
+-- 'SEXP s ty' outside of 'withForeinSEXP'.
+withForeignSEXP
+  :: MonadR m
+  => ForeignSEXP ty
+  -> (forall s . SEXP s ty -> IO r)
+  -> m r
+withForeignSEXP (ForeignSEXP fptr) f =
+    io $ withForeignPtr fptr $ \ptr -> f (SEXP (castPtr ptr))
+-}
+
+withForeignSEXP1
+  ::  ForeignSEXP ty
+  -> (SEXP s ty -> IO r)
+  -> IO r
+withForeignSEXP1 (ForeignSEXP fptr) f =
+    withForeignPtr fptr $ \ptr -> f (SEXP (castPtr ptr))
+
 -- | Immutable vectors. The second type paramater is a phantom parameter
 -- reflecting at the type level the tag of the vector when viewed as a 'SEXP'.
 -- The tag of the vector and the representation type are related via 'ElemRep'.
-newtype Vector s (ty :: SEXPTYPE) a = Vector { unVector :: SEXP s ty }
-
-type instance G.Mutable (Vector r ty) = MVector r ty
+data Vector s (ty :: SEXPTYPE) a = Vector
+  { vectorBase   :: {-# UNPACK #-} !(ForeignSEXP ty)
+  , vectorOffset :: {-# UNPACK #-} !Int32
+  , vectorLength :: {-# UNPACK #-} !Int32
+  }
 
 instance (Eq a, VECTOR s ty a) => Eq (Vector s ty a) where
   a == b = toList a == toList b
@@ -316,31 +366,51 @@ instance (Eq a, VECTOR s ty a) => Eq (Vector s ty a) where
 instance (Show a, VECTOR s ty a)  => Show (Vector s ty a) where
   show v = "fromList " Prelude.++ showList (toList v) ""
 
-instance (VECTOR s ty a)
-         => G.Vector (Vector s ty) a where
-  basicUnsafeFreeze (MVector s)  = return (Vector s)
-  basicUnsafeThaw   (Vector s)   = return (MVector s)
-  basicLength       (Vector s)   =
-      unsafeInlineIO $
-      fromIntegral <$> -- ({# get VECSEXP->vecsxp.length #} (R.unsexp s) :: IO Int32)
-        ((\ ptr -> do { peekByteOff ptr 32 :: IO CInt }) (R.unsexp s))
-  -- XXX Basic unsafe slice is O(N) complexity as it allocates a copy of
-  -- a vector, due to limitations of R's VECSXP structure, which we reuse
-  -- directly.
-  basicUnsafeSlice i l v         = unsafeInlineIO $ do
-    mv <- Mutable.new l
-    copyArray (toMVecPtr mv)
-              (toVecPtr v `plusPtr` i)
-              l
-    G.basicUnsafeFreeze mv
-  basicUnsafeIndexM v i          = return . unsafeInlineIO
-                                 $ peekElemOff (toVecPtr v) i
-  basicUnsafeCopy   mv v         = unsafePrimToPrim $
-    copyArray (toMVecPtr mv)
-              (toVecPtr v)
-              (G.basicLength v)
+-- | Internal wrapper type for reflection. First type parameter is the reified
+-- type to reflect.
+newtype W t ty s a = W { unW :: Vector s ty a }
 
-  elemseq _                      = seq
+withW :: proxy t -> Vector s ty a -> W t ty s a
+withW _ v = W v
+
+proxyFW :: (W t ty s a -> r) -> Vector s ty a -> p t -> r
+proxyFW f v p = f (withW p v)
+
+proxyFW2 :: (W t tya s a -> W t tyb s b -> r) -> Vector s tya a -> Vector s tyb b -> p t -> r
+proxyFW2 f v1 v2 p = f (withW p v1) (withW p v2)
+
+proxyW :: (W t ty s a) -> p t -> Vector s ty a
+proxyW v _ = unW v
+
+type instance G.Mutable (W t ty s) = Mutable.W t ty
+
+instance (Reifies t (AcquireIO s), VECTOR s ty a) => G.Vector (W t ty s) a where
+  {-# INLINE basicUnsafeFreeze #-}
+  basicUnsafeFreeze (Mutable.unW -> Mutable.MVector sx off len) = do
+      fp <- foreignSEXP sx
+      return $ W $ Vector fp off len
+  {-# INLINE basicUnsafeThaw #-}
+  basicUnsafeThaw (unW -> Vector fp off len) = unsafePrimToPrim $
+      withForeignSEXP1 fp $ \ptr -> do
+         sx' <- acquireIO (R.release ptr)
+         return $ Mutable.withW p $ Mutable.MVector (R.unsafeRelease sx') off len
+    where
+      AcquireIO acquireIO = reflect (Proxy :: Proxy t)
+      p = Proxy :: Proxy t
+  basicLength (unW -> Vector _ _ len) = fromIntegral len
+  {-# INLINE basicUnsafeSlice #-}
+  basicUnsafeSlice (fromIntegral ->i) 
+     (fromIntegral ->n) (unW -> Vector fp off _len) = W $ Vector fp (off + i) n
+  {-# INLINE basicUnsafeIndexM #-}
+  basicUnsafeIndexM v i = return . unsafeInlineIO $ peekElemOff (unsafeToPtr (unW v)) i
+  {-# INLINE basicUnsafeCopy #-}
+  basicUnsafeCopy mv v =
+      unsafePrimToPrim $
+        copyArray (Mutable.unsafeToPtr (Mutable.unW mv))
+                  (unsafeToPtr (unW v))
+                  (G.basicLength v)
+  {-# INLINE elemseq #-}
+  elemseq _ = seq
 
 #if __GLASGOW_HASKELL__ >= 708
 instance VECTOR s ty a => Exts.IsList (Vector s ty a) where
@@ -350,18 +420,18 @@ instance VECTOR s ty a => Exts.IsList (Vector s ty a) where
   toList = toList
 #endif
 
-toVecPtr :: Vector s ty a -> Ptr a
-toVecPtr mv = castPtr (R.unsafeSEXPToVectorPtr $ unVector mv)
-
-toMVecPtr :: MVector s ty r a -> Ptr a
-toMVecPtr mv = castPtr (R.unsafeSEXPToVectorPtr $ unMVector mv)
+-- | Return Pointer of the first element of the vector storage.
+unsafeToPtr :: Vector s ty a -> Ptr a
+{-# INLINE unsafeToPtr #-}
+unsafeToPtr v = unsafeInlineIO $ withForeignSEXP1 (vectorBase v) $ \p ->
+   return $  (R.unsafeSEXPToVectorPtr p `plusPtr` (fromIntegral $ vectorOffset v))
 
 -- | /O(n)/ Create an immutable vector from a 'SEXP'. Because 'SEXP's are
 -- mutable, this function yields an immutable /copy/ of the 'SEXP'.
-fromSEXP :: (VECTOR s ty a, PrimMonad m)
-         => SEXP s ty
-         -> m (Vector s ty a)
-fromSEXP s = G.freeze (Mutable.fromSEXP s)
+fromSEXP :: (VECTOR s ty a) => SEXP s ty -> Vector s ty a
+fromSEXP s = phony $ \p -> runST $ do w <- run (proxyFW G.clone (unsafeFromSEXP s) p) 
+                                      v <- G.unsafeFreeze w
+                                      return (unW v)
 
 -- | /O(1)/ Unsafe convert a mutable 'SEXP' to an immutable vector without
 -- copying. The mutable vector must not be used after this operation, lest one
@@ -369,31 +439,35 @@ fromSEXP s = G.freeze (Mutable.fromSEXP s)
 unsafeFromSEXP :: VECTOR s ty a
                => SEXP s ty
                -> Vector s ty a
-unsafeFromSEXP s = Vector s
+unsafeFromSEXP s = unsafeInlineIO $ do
+  sxp <- foreignSEXP s
+  l <- R.length s
+  return $ Vector sxp 0 (fromIntegral l)
 
 -- | /O(n)/ Yield a (mutable) copy of the vector as a 'SEXP'.
-toSEXP :: (VECTOR s ty a, PrimMonad m)
-       => Vector s ty a
-       -> m (SEXP s ty)
-toSEXP = liftM Mutable.toSEXP . G.thaw
+toSEXP :: VECTOR s ty a => Vector s ty a -> SEXP s ty
+toSEXP s = phony $ \p -> runST $ do w <- run (proxyFW G.clone s p)
+                                    v <- G.unsafeFreeze w
+                                    return (unsafeToSEXP (unW v))
 
 -- | /O(1)/ Unsafely convert an immutable vector to a (mutable) 'SEXP' without
 -- copying. The immutable vector must not be used after this operation.
-unsafeToSEXP :: (VECTOR s ty a, PrimMonad m)
-             => Vector s ty a
-             -> m (SEXP s ty)
-unsafeToSEXP = liftM Mutable.toSEXP . G.unsafeThaw
+unsafeToSEXP :: VECTOR s ty a => Vector s ty a -> SEXP s ty
+unsafeToSEXP (Vector (ForeignSEXP fsx) _ _) = unsafePerformIO $ -- XXX
+  withForeignPtr fsx $ return . R.sexp . castPtr
 
 -- | /O(n)/ Convert a character vector into a 'String'.
 toString :: Vector s 'Char Word8 -> String
-toString v = unsafeInlineIO $ GHC.peekCString utf8 . castPtr
-         . R.unsafeSEXPToVectorPtr
-         . unVector $ v
+toString v = unsafeInlineIO $
+  GHC.peekCStringLen utf8 ( castPtr $ unsafeToPtr v
+                          , fromIntegral $ vectorLength v)
 
--- | /O(1)/ Convert a character vector into a strict 'ByteString'.
+
+-- | /O(n)/ Convert a character vector into a strict 'ByteString'.
 toByteString :: Vector s 'Char Word8 -> ByteString
-toByteString v@(Vector p) = unsafeInlineIO
-        $ B.unsafePackCStringLen (castPtr $! R.unsafeSEXPToVectorPtr p, G.length v)
+toByteString v = unsafeInlineIO $ 
+   B.packCStringLen ( castPtr $ unsafeToPtr v
+                    , fromIntegral $ vectorLength v)
 
 ------------------------------------------------------------------------
 -- Vector API
@@ -406,12 +480,12 @@ toByteString v@(Vector p) = unsafeInlineIO
 -- | /O(1)/ Yield the length of the vector.
 length :: VECTOR s ty a => Vector s ty a -> Int
 {-# INLINE length #-}
-length = G.length
+length v = phony $ proxyFW G.length v
 
 -- | /O(1)/ Test whether a vector if empty
 null :: VECTOR s ty a => Vector s ty a -> Bool
 {-# INLINE null #-}
-null = G.null
+null v = phony $ proxyFW G.null v
 
 
 ------------------------------------------------------------------------
@@ -421,37 +495,37 @@ null = G.null
 -- | O(1) Indexing
 (!) :: VECTOR s ty a => Vector s ty a -> Int -> a
 {-# INLINE (!) #-}
-(!) = (G.!)
+(!) v i = phony $ proxyFW (G.! i) v
 
 -- | O(1) Safe indexing
 (!?) :: VECTOR s ty a => Vector s ty a -> Int -> Maybe a
 {-# INLINE (!?) #-}
-(!?) = (G.!?)
+(!?) v i = phony $ proxyFW (G.!? i) v
 
 -- | /O(1)/ First element
 head :: VECTOR s ty a => Vector s ty a -> a
 {-# INLINE head #-}
-head = G.head
+head v = phony $ proxyFW G.head v
 
 -- | /O(1)/ Last element
 last :: VECTOR s ty a => Vector s ty a -> a
 {-# INLINE last #-}
-last = G.last
+last v = phony $ proxyFW G.last v
 
 -- | /O(1)/ Unsafe indexing without bounds checking
 unsafeIndex :: VECTOR s ty a => Vector s ty a -> Int -> a
 {-# INLINE unsafeIndex #-}
-unsafeIndex = G.unsafeIndex
+unsafeIndex v i = phony $ proxyFW (`G.unsafeIndex` i) v
 
 -- | /O(1)/ First element without checking if the vector is empty
 unsafeHead :: VECTOR s ty a => Vector s ty a -> a
 {-# INLINE unsafeHead #-}
-unsafeHead = G.unsafeHead
+unsafeHead v = phony $ proxyFW G.unsafeHead v
 
 -- | /O(1)/ Last element without checking if the vector is empty
 unsafeLast :: VECTOR s ty a => Vector s ty a -> a
 {-# INLINE unsafeLast #-}
-unsafeLast = G.unsafeLast
+unsafeLast v = phony $ proxyFW G.unsafeLast v
 
 ------------------------------------------------------------------------
 -- Monadic indexing
@@ -478,37 +552,37 @@ unsafeLast = G.unsafeLast
 --
 indexM :: (VECTOR s ty a, Monad m) => Vector s ty a -> Int -> m a
 {-# INLINE indexM #-}
-indexM = G.indexM
+indexM v i = phony $ proxyFW (`G.indexM` i) v
 
 -- | /O(1)/ First element of a vector in a monad. See 'indexM' for an
 -- explanation of why this is useful.
 headM :: (VECTOR s ty a, Monad m) => Vector s ty a -> m a
 {-# INLINE headM #-}
-headM = G.headM
+headM v = phony $ proxyFW G.headM v
 
 -- | /O(1)/ Last element of a vector in a monad. See 'indexM' for an
 -- explanation of why this is useful.
 lastM :: (VECTOR s ty a, Monad m) => Vector s ty a -> m a
 {-# INLINE lastM #-}
-lastM = G.lastM
+lastM v = phony $ proxyFW G.lastM v
 
 -- | /O(1)/ Indexing in a monad without bounds checks. See 'indexM' for an
 -- explanation of why this is useful.
 unsafeIndexM :: (VECTOR s ty a, Monad m) => Vector s ty a -> Int -> m a
 {-# INLINE unsafeIndexM #-}
-unsafeIndexM = G.unsafeIndexM
+unsafeIndexM v = phony $ proxyFW G.unsafeIndexM v
 
 -- | /O(1)/ First element in a monad without checking for empty vectors.
 -- See 'indexM' for an explanation of why this is useful.
 unsafeHeadM :: (VECTOR s ty a, Monad m) => Vector s ty a -> m a
 {-# INLINE unsafeHeadM #-}
-unsafeHeadM = G.unsafeHeadM
+unsafeHeadM v = phony $ proxyFW G.unsafeHeadM v
 
 -- | /O(1)/ Last element in a monad without checking for empty vectors.
 -- See 'indexM' for an explanation of why this is useful.
 unsafeLastM :: (VECTOR s ty a, Monad m) => Vector s ty a -> m a
 {-# INLINE unsafeLastM #-}
-unsafeLastM = G.unsafeLastM
+unsafeLastM v = phony $ proxyFW G.unsafeLastM v
 
 ------------------------------------------------------------------------
 -- Extracting subvectors (slicing)
@@ -522,30 +596,30 @@ slice :: VECTOR s ty a
       -> Vector s ty a
       -> Vector s ty a
 {-# INLINE slice #-}
-slice = G.slice
+slice i n v = phony $ unW . proxyFW (G.slice i n) v
 
 -- | /O(N)/ Yield all but the last element, this operation will copy an array.
 -- The vector may not be empty.
 init :: VECTOR s ty a => Vector s ty a -> Vector s ty a
 {-# INLINE init #-}
-init = G.init
+init v = phony $ unW . proxyFW G.init v
 
 -- | /O(N)/ Copy all but the first element. The vector may not be empty.
 tail :: VECTOR s ty a => Vector s ty a -> Vector s ty a
 {-# INLINE tail #-}
-tail = G.tail
+tail v = phony $ unW . proxyFW G.tail v
 
 -- | /O(N)/ Yield at the first @n@ elements with copying. The vector may
 -- contain less than @n@ elements in which case it is returned unchanged.
 take :: VECTOR s ty a => Int -> Vector s ty a -> Vector s ty a
 {-# INLINE take #-}
-take = G.take
+take i v = phony $ unW . proxyFW (G.take i) v
 
 -- | /O(N)/ Yield all but the first @n@ elements with copying. The vector may
 -- contain less than @n@ elements in which case an empty vector is returned.
 drop :: VECTOR s ty a => Int -> Vector s ty a -> Vector s ty a
 {-# INLINE drop #-}
-drop = G.drop
+drop i v = phony $ unW . proxyFW (G.drop i) v
 
 -- | /O(N)/ Yield the first @n@ elements paired with the remainder with copying.
 --
@@ -553,7 +627,7 @@ drop = G.drop
 -- but slightly more efficient.
 {-# INLINE splitAt #-}
 splitAt :: VECTOR s ty a => Int -> Vector s ty a -> (Vector s ty a, Vector s ty a)
-splitAt = G.splitAt
+splitAt i v = phony $ (\(a,b) -> (unW a, unW b)) . proxyFW (G.splitAt i) v
 
 -- | /O(N)/ Yield a slice of the vector with copying. The vector must
 -- contain at least @i+n@ elements but this is not checked.
@@ -562,31 +636,31 @@ unsafeSlice :: VECTOR s ty a => Int   -- ^ @i@ starting index
                        -> Vector s ty a
                        -> Vector s ty a
 {-# INLINE unsafeSlice #-}
-unsafeSlice = G.unsafeSlice
+unsafeSlice i j v = phony $ unW . proxyFW (G.unsafeSlice i j) v
 
 -- | /O(N)/ Yield all but the last element with copying. The vector may not
 -- be empty but this is not checked.
 unsafeInit :: VECTOR s ty a => Vector s ty a -> Vector s ty a
 {-# INLINE unsafeInit #-}
-unsafeInit = G.unsafeInit
+unsafeInit v = phony $ unW . proxyFW G.unsafeInit v
 
 -- | /O(N)/ Yield all but the first element with copying. The vector may not
 -- be empty but this is not checked.
 unsafeTail :: VECTOR s ty a => Vector s ty a -> Vector s ty a
 {-# INLINE unsafeTail #-}
-unsafeTail = G.unsafeTail
+unsafeTail v = phony $ unW . proxyFW G.unsafeTail v
 
 -- | /O(N)/ Yield the first @n@ elements with copying. The vector must
 -- contain at least @n@ elements but this is not checked.
 unsafeTake :: VECTOR s ty a => Int -> Vector s ty a -> Vector s ty a
 {-# INLINE unsafeTake #-}
-unsafeTake = G.unsafeTake
+unsafeTake i v = phony $ unW . proxyFW (G.unsafeTake i) v
 
 -- | /O(N)/ Yield all but the first @n@ elements with copying. The vector
 -- must contain at least @n@ elements but this is not checked.
 unsafeDrop :: VECTOR s ty a => Int -> Vector s ty a -> Vector s ty a
 {-# INLINE unsafeDrop #-}
-unsafeDrop = G.unsafeDrop
+unsafeDrop i v = phony $ unW . proxyFW (G.unsafeDrop i) v
 
 -- Initialisation
 -- --------------
@@ -594,32 +668,31 @@ unsafeDrop = G.unsafeDrop
 -- | /O(1)/ Empty vector
 empty :: VECTOR s ty a => Vector s ty a
 {-# INLINE empty #-}
-empty = G.empty -- TODO test
+empty = phony $ proxyW G.empty
 
 -- | /O(1)/ Vector with exactly one element
 singleton :: VECTOR s ty a => a -> Vector s ty a
 {-# INLINE singleton #-}
-singleton = G.singleton
+singleton a = phony $ proxyW (G.singleton a)
 
 -- | /O(n)/ Vector of the given length with the same value in each position
 replicate :: VECTOR s ty a => Int -> a -> Vector s ty a
 {-# INLINE replicate #-}
-replicate = G.replicate
+replicate i v = phony $ proxyW (G.replicate i v)
 
 -- | /O(n)/ Construct a vector of the given length by applying the function to
 -- each index
 generate :: VECTOR s ty a => Int -> (Int -> a) -> Vector s ty a
 {-# INLINE generate #-}
-generate = G.generate
+generate i f = phony $ proxyW (G.generate i f)
 
 -- | /O(n)/ Apply function n times to value. Zeroth element is original value.
 iterateN :: VECTOR s ty a => Int -> (a -> a) -> a -> Vector s ty a
 {-# INLINE iterateN #-}
-iterateN = G.iterateN
+iterateN i f a = phony $ proxyW (G.iterateN i f a)
 
 -- Unfolding
 -- ---------
-
 -- | /O(n)/ Construct a Vector s ty by repeatedly applying the generator function
 -- to a seed. The generator function yields 'Just' the next element and the
 -- new seed or 'Nothing' if there are no more elements.
@@ -628,7 +701,7 @@ iterateN = G.iterateN
 -- >  = <10,9,8,7,6,5,4,3,2,1>
 unfoldr :: VECTOR s ty a => (b -> Maybe (a, b)) -> b -> Vector s ty a
 {-# INLINE unfoldr #-}
-unfoldr = G.unfoldr
+unfoldr g a = phony $ proxyW (G.unfoldr g a)
 
 -- | /O(n)/ Construct a vector with at most @n@ by repeatedly applying the
 -- generator function to the a seed. The generator function yields 'Just' the
@@ -637,7 +710,7 @@ unfoldr = G.unfoldr
 -- > unfoldrN 3 (\n -> Just (n,n-1)) 10 = <10,9,8>
 unfoldrN :: VECTOR s ty a => Int -> (b -> Maybe (a, b)) -> b -> Vector s ty a
 {-# INLINE unfoldrN #-}
-unfoldrN = G.unfoldrN
+unfoldrN n g a = phony $ proxyW (G.unfoldrN n g a)
 
 -- | /O(n)/ Construct a vector with @n@ elements by repeatedly applying the
 -- generator function to the already constructed part of the vector.
@@ -646,7 +719,7 @@ unfoldrN = G.unfoldrN
 --
 constructN :: VECTOR s ty a => Int -> (Vector s ty a -> a) -> Vector s ty a
 {-# INLINE constructN #-}
-constructN = G.constructN
+constructN n g = phony $ proxyW (G.constructN n (g.unW))
 
 -- | /O(n)/ Construct a vector with @n@ elements from right to left by
 -- repeatedly applying the generator function to the already constructed part
@@ -656,7 +729,7 @@ constructN = G.constructN
 --
 constructrN :: VECTOR s ty a => Int -> (Vector s ty a -> a) -> Vector s ty a
 {-# INLINE constructrN #-}
-constructrN = G.constructrN
+constructrN n g = phony $ proxyW (G.constructrN n (g.unW))
 
 -- Enumeration
 -- -----------
@@ -667,7 +740,7 @@ constructrN = G.constructrN
 -- > enumFromN 5 3 = <5,6,7>
 enumFromN :: (VECTOR s ty a, Num a) => a -> Int -> Vector s ty a
 {-# INLINE enumFromN #-}
-enumFromN = G.enumFromN
+enumFromN a i = phony $ proxyW (G.enumFromN a i)
 
 -- | /O(n)/ Yield a vector of the given length containing the values @x@, @x+y@,
 -- @x+y+y@ etc. This operations is usually more efficient than 'enumFromThenTo'.
@@ -675,7 +748,7 @@ enumFromN = G.enumFromN
 -- > enumFromStepN 1 0.1 5 = <1,1.1,1.2,1.3,1.4>
 enumFromStepN :: (VECTOR s ty a, Num a) => a -> a -> Int -> Vector s ty a
 {-# INLINE enumFromStepN #-}
-enumFromStepN = G.enumFromStepN
+enumFromStepN f t s = phony $ proxyW (G.enumFromStepN f t s)
 
 -- | /O(n)/ Enumerate values from @x@ to @y@.
 --
@@ -683,7 +756,7 @@ enumFromStepN = G.enumFromStepN
 -- 'enumFromN' instead.
 enumFromTo :: (VECTOR s ty a, Enum a) => a -> a -> Vector s ty a
 {-# INLINE enumFromTo #-}
-enumFromTo = G.enumFromTo
+enumFromTo f t = phony $ proxyW (G.enumFromTo f t)
 
 -- | /O(n)/ Enumerate values from @x@ to @y@ with a specific step @z@.
 --
@@ -691,7 +764,7 @@ enumFromTo = G.enumFromTo
 -- 'enumFromStepN' instead.
 enumFromThenTo :: (VECTOR s ty a, Enum a) => a -> a -> a -> Vector s ty a
 {-# INLINE enumFromThenTo #-}
-enumFromThenTo = G.enumFromThenTo
+enumFromThenTo f t s = phony $ proxyW (G.enumFromThenTo f t s)
 
 -- Concatenation
 -- -------------
@@ -699,23 +772,23 @@ enumFromThenTo = G.enumFromThenTo
 -- | /O(n)/ Prepend an element
 cons :: VECTOR s ty a => a -> Vector s ty a -> Vector s ty a
 {-# INLINE cons #-}
-cons = G.cons
+cons a v = phony $ unW . proxyFW (G.cons a) v
 
 -- | /O(n)/ Append an element
 snoc :: VECTOR s ty a => Vector s ty a -> a -> Vector s ty a
 {-# INLINE snoc #-}
-snoc = G.snoc
+snoc v a = phony $ unW . proxyFW (`G.snoc` a) v
 
 infixr 5 ++
 -- | /O(m+n)/ Concatenate two vectors
 (++) :: VECTOR s ty a => Vector s ty a -> Vector s ty a -> Vector s ty a
 {-# INLINE (++) #-}
-(++) = (G.++)
+v1 ++ v2 = phony $ unW . proxyFW2 (G.++) v1 v2 
 
 -- | /O(n)/ Concatenate all vectors in the list
 concat :: VECTOR s ty a => [Vector s ty a] -> Vector s ty a
 {-# INLINE concat #-}
-concat = G.concat
+concat vs = phony $ \p -> unW $ G.concat $ Prelude.map (withW p) vs
 
 -- Monadic initialisation
 -- ----------------------
@@ -724,24 +797,28 @@ concat = G.concat
 -- results in a vector.
 replicateM :: (Monad m, VECTOR s ty a) => Int -> m a -> m (Vector s ty a)
 {-# INLINE replicateM #-}
-replicateM = G.replicateM
+replicateM n f = phony $ \p -> (\v -> proxyW v p) <$> G.replicateM n f
 
 -- | /O(n)/ Construct a vector of the given length by applying the monadic
 -- action to each index
 generateM :: (Monad m, VECTOR s ty a) => Int -> (Int -> m a) -> m (Vector s ty a)
 {-# INLINE generateM #-}
-generateM = G.generateM
+generateM n f = phony $ \p -> (\v -> proxyW v p) <$> G.generateM n f
 
+{-
+-- XXX:
 -- | Execute the monadic action and freeze the resulting vector.
 --
 -- @
 -- create (do { v \<- new 2; write v 0 \'a\'; write v 1 \'b\'; return v }) = \<'a','b'\>
 -- @
-create :: VECTOR s ty a => (forall r. ST r (MVector s ty r a)) -> Vector s ty a
+create :: VECTOR s ty a => (forall r. ST r (MVector s ty a)) -> Vector s ty a
 {-# INLINE create #-}
 -- NOTE: eta-expanded due to http://hackage.haskell.org/trac/ghc/ticket/4120
-create p = G.create p
-
+create p = withAcquire $ \z -> do
+  x <- G.create (Mutable.withW z <$> p)
+  -- phony $ \z -> _undefined (G.create (Mutable.withW z <$> p))
+-}
 
 -- Restricting memory usage
 -- ------------------------
@@ -758,7 +835,7 @@ create p = G.create p
 -- vector to be garbage collected.
 force :: VECTOR s ty a => Vector s ty a -> Vector s ty a
 {-# INLINE force #-}
-force = G.force
+force v = phony $ unW . proxyFW G.force v
 
 -- Bulk updates
 -- ------------
@@ -772,7 +849,7 @@ force = G.force
                 -> [(Int, a)] -- ^ list of index/value pairs (of length @n@)
                 -> Vector s ty a
 {-# INLINE (//) #-}
-(//) = (G.//)
+(//) v l = phony $ unW . proxyFW (G.// l) v
 
 {-
 -- | /O(m+min(n1,n2))/ For each index @i@ from the index Vector s ty and the
@@ -790,12 +867,10 @@ update_ :: VECTOR s ty a
 update_ = G.update_
 -}
 
-{-
 -- | Same as ('//') but without bounds checking.
 unsafeUpd :: VECTOR s ty a => Vector s ty a -> [(Int, a)] -> Vector s ty a
 {-# INLINE unsafeUpd #-}
-unsafeUpd = G.unsafeUpd
--}
+unsafeUpd v l = phony $ unW . proxyFW (`G.unsafeUpd` l) v
 
 {-
 -- | Same as 'update_' but without bounds checking.
@@ -817,7 +892,7 @@ accum :: VECTOR s ty a
       -> [(Int,b)]     -- ^ list of index/value pairs (of length @n@)
       -> Vector s ty a
 {-# INLINE accum #-}
-accum = G.accum
+accum f v l = phony $ unW . proxyFW (\w -> G.accum f w l) v
 
 {-
 -- | /O(m+min(n1,n2))/ For each index @i@ from the index Vector s ty and the
@@ -840,7 +915,7 @@ accumulate_ = G.accumulate_
 -- | Same as 'accum' but without bounds checking.
 unsafeAccum :: VECTOR s ty a => (a -> b -> a) -> Vector s ty a -> [(Int,b)] -> Vector s ty a
 {-# INLINE unsafeAccum #-}
-unsafeAccum = G.unsafeAccum
+unsafeAccum f v l = phony $ unW . proxyFW (\w -> G.unsafeAccum f w l) v
 
 {-
 -- | Same as 'accumulate_' but without bounds checking.
@@ -856,7 +931,7 @@ unsafeAccumulate_ = G.unsafeAccumulate_
 -- | /O(n)/ Reverse a vector
 reverse :: VECTOR s ty a => Vector s ty a -> Vector s ty a
 {-# INLINE reverse #-}
-reverse = G.reverse
+reverse v = phony $ unW . proxyFW G.reverse v
 
 {-
 -- | /O(n)/ Yield the vector obtained by replacing each element @i@ of the
@@ -898,17 +973,19 @@ modify p = G.modify p
 -- | /O(n)/ Map a function over a vector
 map :: (VECTOR s ty a, VECTOR s ty b) => (a -> b) -> Vector s ty a -> Vector s ty b
 {-# INLINE map #-}
-map = G.map
+map f v = phony $ unW . proxyFW (G.map f) v
 
 -- | /O(n)/ Apply a function to every element of a Vector s ty and its index
 imap :: (VECTOR s ty a, VECTOR s ty b) => (Int -> a -> b) -> Vector s ty a -> Vector s ty b
 {-# INLINE imap #-}
-imap = G.imap
+imap f v = phony $ unW . proxyFW (G.imap f) v
 
+{-
 -- | Map a function over a Vector s ty and concatenate the results.
-concatMap :: (VECTOR s ty a, VECTOR s ty b) => (a -> Vector s ty b) -> Vector s ty a -> Vector s ty b
+concatMap :: (VECTOR s ty a, VECTOR s tyb b) => (a -> Vector s tyb b) -> Vector s ty a -> Vector s tyb b
 {-# INLINE concatMap #-}
-concatMap = G.concatMap
+concatMap f v = phony $ \p -> unW $ proxyFW (G.concatMap (withW p . f)) v p
+-}
 
 -- Monadic mapping
 -- ---------------
@@ -917,25 +994,25 @@ concatMap = G.concatMap
 -- vector of results
 mapM :: (Monad m, VECTOR s ty a, VECTOR s ty b) => (a -> m b) -> Vector s ty a -> m (Vector s ty b)
 {-# INLINE mapM #-}
-mapM = G.mapM
+mapM f v = phony $ \p -> unW <$> proxyFW (G.mapM f) v p
 
 -- | /O(n)/ Apply the monadic action to all elements of a Vector s ty and ignore the
 -- results
 mapM_ :: (Monad m, VECTOR s ty a) => (a -> m b) -> Vector s ty a -> m ()
 {-# INLINE mapM_ #-}
-mapM_ = G.mapM_
+mapM_ f v = phony $ proxyFW (G.mapM_ f) v
 
 -- | /O(n)/ Apply the monadic action to all elements of the vector, yielding a
 -- vector of results. Equvalent to @flip 'mapM'@.
 forM :: (Monad m, VECTOR s ty a, VECTOR s ty b) => Vector s ty a -> (a -> m b) -> m (Vector s ty b)
 {-# INLINE forM #-}
-forM = G.forM
+forM v f = phony $ \p -> unW <$> proxyFW (`G.forM` f) v p
 
 -- | /O(n)/ Apply the monadic action to all elements of a Vector s ty and ignore the
 -- results. Equivalent to @flip 'mapM_'@.
 forM_ :: (Monad m, VECTOR s ty a) => Vector s ty a -> (a -> m b) -> m ()
 {-# INLINE forM_ #-}
-forM_ = G.forM_
+forM_ v f = phony $ proxyFW (`G.forM_` f) v
 
 -- Zipping
 -- -------
@@ -944,19 +1021,22 @@ forM_ = G.forM_
 zipWith :: (VECTOR s tya a, VECTOR s tyb b, VECTOR s tyc c)
         => (a -> b -> c) -> Vector s tya a -> Vector s tyb b -> Vector s tyc c
 {-# INLINE zipWith #-}
-zipWith f xs ys = G.unstream (Stream.zipWith f (G.stream xs) (G.stream ys))
+zipWith f xs ys = phony $ \p ->
+   proxyW (G.unstream (Stream.zipWith f (G.stream (withW p xs)) (G.stream (withW p ys)))) p
 
 -- | Zip three vectors with the given function.
 zipWith3 :: (VECTOR s tya a, VECTOR s tyb b, VECTOR s tyc c, VECTOR s tyd d)
          => (a -> b -> c -> d) -> Vector s tya a -> Vector s tyb b -> Vector s tyc c -> Vector s tyd d
 {-# INLINE zipWith3 #-}
-zipWith3 f as bs cs = G.unstream (Stream.zipWith3 f (G.stream as) (G.stream bs) (G.stream cs))
+zipWith3 f as bs cs = phony $ \p ->
+  proxyW (G.unstream (Stream.zipWith3 f (G.stream (withW p as)) (G.stream (withW p bs)) (G.stream (withW p cs)))) p
 
 zipWith4 :: (VECTOR s tya a, VECTOR s tyb b, VECTOR s tyc c, VECTOR s tyd d, VECTOR s tye e)
          => (a -> b -> c -> d -> e)
          -> Vector s tya a -> Vector s tyb b -> Vector s tyc c -> Vector s tyd d -> Vector s tye e
 {-# INLINE zipWith4 #-}
-zipWith4 f as bs cs ds = G.unstream (Stream.zipWith4 f (G.stream as) (G.stream bs) (G.stream cs) (G.stream ds))
+zipWith4 f as bs cs ds = phony $ \p ->
+  proxyW (G.unstream (Stream.zipWith4 f (G.stream (withW p as)) (G.stream (withW p bs)) (G.stream (withW p cs)) (G.stream (withW p ds)))) p
 
 zipWith5 :: (VECTOR s tya a, VECTOR s tyb b, VECTOR s tyc c, VECTOR s tyd d, VECTOR s tye e,
              VECTOR s tyf f)
@@ -964,7 +1044,8 @@ zipWith5 :: (VECTOR s tya a, VECTOR s tyb b, VECTOR s tyc c, VECTOR s tyd d, VEC
          -> Vector s tya a -> Vector s tyb b -> Vector s tyc c -> Vector s tyd d -> Vector s tye e
          -> Vector s tyf f
 {-# INLINE zipWith5 #-}
-zipWith5 f as bs cs ds es = G.unstream (Stream.zipWith5 f (G.stream as) (G.stream bs) (G.stream cs) (G.stream ds) (G.stream es))
+zipWith5 f as bs cs ds es = phony $ \p ->
+  proxyW (G.unstream (Stream.zipWith5 f (G.stream (withW p as)) (G.stream (withW p bs)) (G.stream (withW p cs)) (G.stream (withW p ds)) (G.stream (withW p es)))) p
 
 zipWith6 :: (VECTOR s tya a, VECTOR s tyb b, VECTOR s tyc c, VECTOR s tyd d, VECTOR s tye e,
              VECTOR s tyf f, VECTOR s tyg g)
@@ -972,27 +1053,31 @@ zipWith6 :: (VECTOR s tya a, VECTOR s tyb b, VECTOR s tyc c, VECTOR s tyd d, VEC
          -> Vector s tya a -> Vector s tyb b -> Vector s tyc c -> Vector s tyd d -> Vector s tye e
          -> Vector s tyf f -> Vector s tyg g
 {-# INLINE zipWith6 #-}
-zipWith6 f as bs cs ds es fs = G.unstream (Stream.zipWith6 f (G.stream as) (G.stream bs) (G.stream cs) (G.stream ds) (G.stream es) (G.stream fs))
+zipWith6 f as bs cs ds es fs = phony $ \p ->
+  proxyW (G.unstream (Stream.zipWith6 f (G.stream (withW p as)) (G.stream (withW p bs)) (G.stream (withW p cs)) (G.stream (withW p ds)) (G.stream (withW p es)) (G.stream (withW p fs)))) p
 
 -- | /O(min(m,n))/ Zip two vectors with a function that also takes the
 -- elements' indices.
 izipWith :: (VECTOR s tya a, VECTOR s tyb b, VECTOR s tyc c)
          => (Int -> a -> b -> c) -> Vector s tya a -> Vector s tyb b -> Vector s tyc c
 {-# INLINE izipWith #-}
-izipWith f as bs = G.unstream (Stream.zipWith (uncurry f) (Stream.indexed (G.stream as)) (G.stream bs))
+izipWith f as bs = phony $ \p ->
+  proxyW (G.unstream (Stream.zipWith (uncurry f) (Stream.indexed (G.stream (withW p as))) (G.stream (withW p bs)))) p
 
 -- | Zip three vectors and their indices with the given function.
 izipWith3 :: (VECTOR s tya a, VECTOR s tyb b, VECTOR s tyc c, VECTOR s tyd d)
           => (Int -> a -> b -> c -> d)
           -> Vector s tya a -> Vector s tyb b -> Vector s tyc c -> Vector s tyd d
 {-# INLINE izipWith3 #-}
-izipWith3 f as bs cs = G.unstream (Stream.zipWith3 (uncurry f) (Stream.indexed (G.stream as)) (G.stream bs) (G.stream cs))
+izipWith3 f as bs cs = phony $ \p ->
+  proxyW (G.unstream (Stream.zipWith3 (uncurry f) (Stream.indexed (G.stream (withW p as))) (G.stream (withW p bs)) (G.stream (withW p cs)))) p
 
 izipWith4 :: (VECTOR s tya a, VECTOR s tyb b, VECTOR s tyc c, VECTOR s tyd d, VECTOR s tye e)
           => (Int -> a -> b -> c -> d -> e)
           -> Vector s tya a -> Vector s tyb b -> Vector s tyc c -> Vector s tyd d -> Vector s tye e
 {-# INLINE izipWith4 #-}
-izipWith4 f as bs cs ds =  G.unstream (Stream.zipWith4 (uncurry f) (Stream.indexed (G.stream as)) (G.stream bs) (G.stream cs) (G.stream ds))
+izipWith4 f as bs cs ds = phony $ \p ->
+  proxyW (G.unstream (Stream.zipWith4 (uncurry f) (Stream.indexed (G.stream (withW p as))) (G.stream (withW p bs)) (G.stream (withW p cs)) (G.stream (withW p ds)))) p
 
 izipWith5 :: (VECTOR s tya a, VECTOR s tyb b, VECTOR s tyc c, VECTOR s tyd d, VECTOR s tye e,
               VECTOR s tyf f)
@@ -1000,7 +1085,8 @@ izipWith5 :: (VECTOR s tya a, VECTOR s tyb b, VECTOR s tyc c, VECTOR s tyd d, VE
           -> Vector s tya a -> Vector s tyb b -> Vector s tyc c -> Vector s tyd d -> Vector s tye e
           -> Vector s tyf f
 {-# INLINE izipWith5 #-}
-izipWith5 f as bs cs ds es =  G.unstream (Stream.zipWith5 (uncurry f) (Stream.indexed (G.stream as)) (G.stream bs) (G.stream cs) (G.stream ds) (G.stream es))
+izipWith5 f as bs cs ds es = phony $ \p ->
+  proxyW (G.unstream (Stream.zipWith5 (uncurry f) (Stream.indexed (G.stream (withW p as))) (G.stream (withW p bs)) (G.stream (withW p cs)) (G.stream (withW p ds)) (G.stream (withW p es)))) p
 
 izipWith6 :: (VECTOR s tya a, VECTOR s tyb b, VECTOR s tyc c, VECTOR s tyd d, VECTOR s tye e,
               VECTOR s tyf f, VECTOR s tyg g)
@@ -1008,7 +1094,8 @@ izipWith6 :: (VECTOR s tya a, VECTOR s tyb b, VECTOR s tyc c, VECTOR s tyd d, VE
           -> Vector s tya a -> Vector s tyb b -> Vector s tyc c -> Vector s tyd d -> Vector s tye e
           -> Vector s tyf f -> Vector s tyg g
 {-# INLINE izipWith6 #-}
-izipWith6 f as bs cs ds es fs =  G.unstream (Stream.zipWith6 (uncurry f) (Stream.indexed (G.stream as)) (G.stream bs) (G.stream cs) (G.stream ds) (G.stream es) (G.stream fs))
+izipWith6 f as bs cs ds es fs = phony $ \p ->
+  proxyW (G.unstream (Stream.zipWith6 (uncurry f) (Stream.indexed (G.stream (withW p as))) (G.stream (withW p bs)) (G.stream (withW p cs)) (G.stream (withW p ds)) (G.stream (withW p es)) (G.stream (withW p fs)))) p
 
 -- Monadic zipping
 -- ---------------
@@ -1019,15 +1106,16 @@ izipWith6 f as bs cs ds es fs =  G.unstream (Stream.zipWith6 (uncurry f) (Stream
 zipWithM :: (Monad m, VECTOR s tya a, VECTOR s tyb b, VECTOR s tyc c)
          => (a -> b -> m c) -> Vector s tya a -> Vector s tyb b -> m (Vector s tyc c)
 {-# INLINE zipWithM #-}
-zipWithM f as bs = G.unstreamM (Stream.zipWithM f (G.stream as) (G.stream bs))
--}
+zipWithM f as bs = phony $ \p ->
+  proxyFW2 (G.zipWithM f) as bs p
 
 -- | /O(min(m,n))/ Zip the two vectors with the monadic action and ignore the
 -- results
 zipWithM_ :: (Monad m, VECTOR s tya a, VECTOR s tyb b)
           => (a -> b -> m c) -> Vector s tya a -> Vector s tyb b -> m ()
 {-# INLINE zipWithM_ #-}
-zipWithM_ f as bs = Stream.zipWithM_ f (G.stream as) (G.stream bs)
+zipWithM_ f as bs = phony $ proxyFW2 (G.zipWithM_ f) as bs
+-}
 
 -- Filtering
 -- ---------
@@ -1035,30 +1123,30 @@ zipWithM_ f as bs = Stream.zipWithM_ f (G.stream as) (G.stream bs)
 -- | /O(n)/ Drop elements that do not satisfy the predicate
 filter :: VECTOR s ty a => (a -> Bool) -> Vector s ty a -> Vector s ty a
 {-# INLINE filter #-}
-filter = G.filter
+filter f v = phony $ unW . proxyFW (G.filter f) v
 
 -- | /O(n)/ Drop elements that do not satisfy the predicate which is applied to
 -- values and their indices
 ifilter :: VECTOR s ty a => (Int -> a -> Bool) -> Vector s ty a -> Vector s ty a
 {-# INLINE ifilter #-}
-ifilter = G.ifilter
+ifilter f v = phony $ unW . proxyFW (G.ifilter f) v
 
 -- | /O(n)/ Drop elements that do not satisfy the monadic predicate
 filterM :: (Monad m, VECTOR s ty a) => (a -> m Bool) -> Vector s ty a -> m (Vector s ty a)
 {-# INLINE filterM #-}
-filterM = G.filterM
+filterM f v = phony $ \p -> unW <$> proxyFW (G.filterM f) v p
 
 -- | /O(n)/ Yield the longest prefix of elements satisfying the predicate
 -- with copying.
 takeWhile :: VECTOR s ty a => (a -> Bool) -> Vector s ty a -> Vector s ty a
 {-# INLINE takeWhile #-}
-takeWhile = G.takeWhile
+takeWhile f v = phony $ unW . proxyFW (G.takeWhile f) v
 
 -- | /O(n)/ Drop the longest prefix of elements that satisfy the predicate
 -- with copying.
 dropWhile :: VECTOR s ty a => (a -> Bool) -> Vector s ty a -> Vector s ty a
 {-# INLINE dropWhile #-}
-dropWhile = G.dropWhile
+dropWhile f v = phony $ unW . proxyFW (G.dropWhile f) v
 
 -- Parititioning
 -- -------------
@@ -1069,7 +1157,7 @@ dropWhile = G.dropWhile
 -- reduced performance compared to 'unstablePartition'.
 partition :: VECTOR s ty a => (a -> Bool) -> Vector s ty a -> (Vector s ty a, Vector s ty a)
 {-# INLINE partition #-}
-partition = G.partition
+partition f v = phony $ (\(a,b) -> (unW a, unW b)) . proxyFW (G.partition f) v
 
 -- | /O(n)/ Split the vector in two parts, the first one containing those
 -- elements that satisfy the predicate and the second one those that don't.
@@ -1077,19 +1165,19 @@ partition = G.partition
 -- faster than 'partition'.
 unstablePartition :: VECTOR s ty a => (a -> Bool) -> Vector s ty a -> (Vector s ty a, Vector s ty a)
 {-# INLINE unstablePartition #-}
-unstablePartition = G.unstablePartition
+unstablePartition f v = phony $ (\(a,b) -> (unW a, unW b)) . proxyFW (G.unstablePartition f) v
 
 -- | /O(n)/ Split the vector into the longest prefix of elements that satisfy
 -- the predicate and the rest with copying.
 span :: VECTOR s ty a => (a -> Bool) -> Vector s ty a -> (Vector s ty a, Vector s ty a)
 {-# INLINE span #-}
-span = G.span
+span f v = phony $ (\(a,b) -> (unW a, unW b)) . proxyFW (G.span f) v
 
 -- | /O(n)/ Split the vector into the longest prefix of elements that do not
 -- satisfy the predicate and the rest with copying.
 break :: VECTOR s ty a => (a -> Bool) -> Vector s ty a -> (Vector s ty a, Vector s ty a)
 {-# INLINE break #-}
-break = G.break
+break f v = phony $ (\(a,b) -> (unW a, unW b)) . proxyFW (G.break f) v
 
 -- Searching
 -- ---------
@@ -1098,32 +1186,32 @@ infix 4 `elem`
 -- | /O(n)/ Check if the vector contains an element
 elem :: (VECTOR s ty a, Eq a) => a -> Vector s ty a -> Bool
 {-# INLINE elem #-}
-elem = G.elem
+elem a v = phony $ proxyFW (G.elem a) v
 
 infix 4 `notElem`
 -- | /O(n)/ Check if the vector does not contain an element (inverse of 'elem')
 notElem :: (VECTOR s ty a, Eq a) => a -> Vector s ty a -> Bool
 {-# INLINE notElem #-}
-notElem = G.notElem
+notElem a v = phony $ proxyFW (G.notElem a) v
 
 -- | /O(n)/ Yield 'Just' the first element matching the predicate or 'Nothing'
 -- if no such element exists.
 find :: VECTOR s ty a => (a -> Bool) -> Vector s ty a -> Maybe a
 {-# INLINE find #-}
-find = G.find
+find f v = phony $ proxyFW (G.find f) v
 
 -- | /O(n)/ Yield 'Just' the index of the first element matching the predicate
 -- or 'Nothing' if no such element exists.
 findIndex :: VECTOR s ty a => (a -> Bool) -> Vector s ty a -> Maybe Int
 {-# INLINE findIndex #-}
-findIndex = G.findIndex
+findIndex f v = phony $ proxyFW (G.findIndex f) v
 
 {-
 -- | /O(n)/ Yield the indices of elements satisfying the predicate in ascending
 -- order.
 findIndices :: VECTOR s ty a => (a -> Bool) -> Vector s ty a -> Vector Int
 {-# INLINE findIndices #-}
-findIndices = G.findIndices
+findIndices f v = phony $ proxyFW (G.findIndices f) v
 -}
 
 -- | /O(n)/ Yield 'Just' the index of the first occurence of the given element or
@@ -1131,14 +1219,14 @@ findIndices = G.findIndices
 -- version of 'findIndex'.
 elemIndex :: (VECTOR s ty a, Eq a) => a -> Vector s ty a -> Maybe Int
 {-# INLINE elemIndex #-}
-elemIndex = G.elemIndex
+elemIndex a v = phony $ proxyFW (G.elemIndex a) v
 
 {-
 -- | /O(n)/ Yield the indices of all occurences of the given element in
 -- ascending order. This is a specialised version of 'findIndices'.
-elemIndices :: (VECTOR s ty a, Eq a) => a -> Vector s ty a -> Vector Int
+elemIndices :: (VECTOR s ty a, Eq a) => a -> Vector s ty a -> Vector s 'R.Int Int32
 {-# INLINE elemIndices #-}
-elemIndices = G.elemIndices
+elemIndices s v = phony $ unW . proxyFW (G.elemIndices s) v
 -}
 
 -- Folding
@@ -1147,64 +1235,64 @@ elemIndices = G.elemIndices
 -- | /O(n)/ Left fold
 foldl :: VECTOR s ty b => (a -> b -> a) -> a -> Vector s ty b -> a
 {-# INLINE foldl #-}
-foldl = G.foldl
+foldl f s v = phony $ proxyFW (G.foldl f s) v
 
 -- | /O(n)/ Left fold on non-empty vectors
 foldl1 :: VECTOR s ty a => (a -> a -> a) -> Vector s ty a -> a
 {-# INLINE foldl1 #-}
-foldl1 = G.foldl1
+foldl1 f v = phony $ proxyFW (G.foldl1 f) v
 
 -- | /O(n)/ Left fold with strict accumulator
 foldl' :: VECTOR s ty b => (a -> b -> a) -> a -> Vector s ty b -> a
 {-# INLINE foldl' #-}
-foldl' = G.foldl'
+foldl' f s v = phony $ proxyFW (G.foldl' f s) v
 
 -- | /O(n)/ Left fold on non-empty vectors with strict accumulator
 foldl1' :: VECTOR s ty a => (a -> a -> a) -> Vector s ty a -> a
 {-# INLINE foldl1' #-}
-foldl1' = G.foldl1'
+foldl1' f v  = phony $ proxyFW (G.foldl1' f) v
 
 -- | /O(n)/ Right fold
 foldr :: VECTOR s ty a => (a -> b -> b) -> b -> Vector s ty a -> b
 {-# INLINE foldr #-}
-foldr = G.foldr
+foldr f s v = phony $ proxyFW (G.foldr f s) v
 
 -- | /O(n)/ Right fold on non-empty vectors
 foldr1 :: VECTOR s ty a => (a -> a -> a) -> Vector s ty a -> a
 {-# INLINE foldr1 #-}
-foldr1 = G.foldr1
+foldr1 f v = phony $ proxyFW (G.foldr1 f) v
 
 -- | /O(n)/ Right fold with a strict accumulator
 foldr' :: VECTOR s ty a => (a -> b -> b) -> b -> Vector s ty a -> b
 {-# INLINE foldr' #-}
-foldr' = G.foldr'
+foldr' f s v = phony $ proxyFW (G.foldr' f s) v
 
 -- | /O(n)/ Right fold on non-empty vectors with strict accumulator
 foldr1' :: VECTOR s ty a => (a -> a -> a) -> Vector s ty a -> a
 {-# INLINE foldr1' #-}
-foldr1' = G.foldr1'
+foldr1' f v = phony $ proxyFW (G.foldr1' f) v
 
 -- | /O(n)/ Left fold (function applied to each element and its index)
 ifoldl :: VECTOR s ty b => (a -> Int -> b -> a) -> a -> Vector s ty b -> a
 {-# INLINE ifoldl #-}
-ifoldl = G.ifoldl
+ifoldl f s v = phony $ proxyFW (G.ifoldl f s) v
 
 -- | /O(n)/ Left fold with strict accumulator (function applied to each element
 -- and its index)
 ifoldl' :: VECTOR s ty b => (a -> Int -> b -> a) -> a -> Vector s ty b -> a
 {-# INLINE ifoldl' #-}
-ifoldl' = G.ifoldl'
+ifoldl' f s  v = phony $ proxyFW (G.ifoldl' f s) v
 
 -- | /O(n)/ Right fold (function applied to each element and its index)
 ifoldr :: VECTOR s ty a => (Int -> a -> b -> b) -> b -> Vector s ty a -> b
 {-# INLINE ifoldr #-}
-ifoldr = G.ifoldr
+ifoldr f s v = phony $ proxyFW (G.ifoldr f s) v
 
 -- | /O(n)/ Right fold with strict accumulator (function applied to each
 -- element and its index)
 ifoldr' :: VECTOR s ty a => (Int -> a -> b -> b) -> b -> Vector s ty a -> b
 {-# INLINE ifoldr' #-}
-ifoldr' = G.ifoldr'
+ifoldr' f s v = phony $ proxyFW (G.ifoldr' f s) v
 
 -- Specialised folds
 -- -----------------
@@ -1234,60 +1322,60 @@ or = G.or
 -- | /O(n)/ Compute the sum of the elements
 sum :: (VECTOR s ty a, Num a) => Vector s ty a -> a
 {-# INLINE sum #-}
-sum = G.sum
+sum v = phony $ proxyFW G.sum v
 
 -- | /O(n)/ Compute the produce of the elements
 product :: (VECTOR s ty a, Num a) => Vector s ty a -> a
 {-# INLINE product #-}
-product = G.product
+product v = phony $ proxyFW G.product v
 
 -- | /O(n)/ Yield the maximum element of the vector. The vector may not be
 -- empty.
 maximum :: (VECTOR s ty a, Ord a) => Vector s ty a -> a
 {-# INLINE maximum #-}
-maximum = G.maximum
+maximum v = phony $ proxyFW G.maximum v
 
 -- | /O(n)/ Yield the maximum element of the Vector s ty according to the given
 -- comparison function. The vector may not be empty.
 maximumBy :: VECTOR s ty a => (a -> a -> Ordering) -> Vector s ty a -> a
 {-# INLINE maximumBy #-}
-maximumBy = G.maximumBy
+maximumBy f v = phony $ proxyFW (G.maximumBy f) v
 
 -- | /O(n)/ Yield the minimum element of the vector. The vector may not be
 -- empty.
 minimum :: (VECTOR s ty a, Ord a) => Vector s ty a -> a
 {-# INLINE minimum #-}
-minimum = G.minimum
+minimum v = phony $ proxyFW G.minimum v
 
 -- | /O(n)/ Yield the minimum element of the Vector s ty according to the given
 -- comparison function. The vector may not be empty.
 minimumBy :: VECTOR s ty a => (a -> a -> Ordering) -> Vector s ty a -> a
 {-# INLINE minimumBy #-}
-minimumBy = G.minimumBy
+minimumBy f v = phony $ proxyFW (G.minimumBy f) v
 
 -- | /O(n)/ Yield the index of the maximum element of the vector. The vector
 -- may not be empty.
 maxIndex :: (VECTOR s ty a, Ord a) => Vector s ty a -> Int
 {-# INLINE maxIndex #-}
-maxIndex = G.maxIndex
+maxIndex v = phony $ proxyFW G.maxIndex v
 
 -- | /O(n)/ Yield the index of the maximum element of the Vector s ty according to
 -- the given comparison function. The vector may not be empty.
 maxIndexBy :: VECTOR s ty a => (a -> a -> Ordering) -> Vector s ty a -> Int
 {-# INLINE maxIndexBy #-}
-maxIndexBy = G.maxIndexBy
+maxIndexBy f v = phony $ proxyFW (G.maxIndexBy f) v
 
 -- | /O(n)/ Yield the index of the minimum element of the vector. The vector
 -- may not be empty.
 minIndex :: (VECTOR s ty a, Ord a) => Vector s ty a -> Int
 {-# INLINE minIndex #-}
-minIndex = G.minIndex
+minIndex v = phony $ proxyFW G.minIndex v
 
 -- | /O(n)/ Yield the index of the minimum element of the Vector s ty according to
 -- the given comparison function. The vector may not be empty.
 minIndexBy :: VECTOR s ty a => (a -> a -> Ordering) -> Vector s ty a -> Int
 {-# INLINE minIndexBy #-}
-minIndexBy = G.minIndexBy
+minIndexBy f v = phony $ proxyFW (G.minIndexBy f) v
 
 -- Monadic folds
 -- -------------
@@ -1295,43 +1383,43 @@ minIndexBy = G.minIndexBy
 -- | /O(n)/ Monadic fold
 foldM :: (Monad m, VECTOR s ty b) => (a -> b -> m a) -> a -> Vector s ty b -> m a
 {-# INLINE foldM #-}
-foldM = G.foldM
+foldM f s v = phony $ proxyFW (G.foldM f s) v
 
 -- | /O(n)/ Monadic fold over non-empty vectors
 fold1M :: (Monad m, VECTOR s ty a) => (a -> a -> m a) -> Vector s ty a -> m a
 {-# INLINE fold1M #-}
-fold1M = G.fold1M
+fold1M f v = phony $ proxyFW (G.fold1M f) v
 
 -- | /O(n)/ Monadic fold with strict accumulator
 foldM' :: (Monad m, VECTOR s ty b) => (a -> b -> m a) -> a -> Vector s ty b -> m a
 {-# INLINE foldM' #-}
-foldM' = G.foldM'
+foldM' f s v = phony $ proxyFW (G.foldM' f s) v
 
 -- | /O(n)/ Monadic fold over non-empty vectors with strict accumulator
 fold1M' :: (Monad m, VECTOR s ty a) => (a -> a -> m a) -> Vector s ty a -> m a
 {-# INLINE fold1M' #-}
-fold1M' = G.fold1M'
+fold1M' f v = phony $ proxyFW (G.fold1M' f) v
 
 -- | /O(n)/ Monadic fold that discards the result
 foldM_ :: (Monad m, VECTOR s ty b) => (a -> b -> m a) -> a -> Vector s ty b -> m ()
 {-# INLINE foldM_ #-}
-foldM_ = G.foldM_
+foldM_ f s v = phony $ proxyFW (G.foldM_ f s) v
 
 -- | /O(n)/ Monadic fold over non-empty vectors that discards the result
 fold1M_ :: (Monad m, VECTOR s ty a) => (a -> a -> m a) -> Vector s ty a -> m ()
 {-# INLINE fold1M_ #-}
-fold1M_ = G.fold1M_
+fold1M_ f v = phony $ proxyFW (G.fold1M_ f) v
 
 -- | /O(n)/ Monadic fold with strict accumulator that discards the result
 foldM'_ :: (Monad m, VECTOR s ty b) => (a -> b -> m a) -> a -> Vector s ty b -> m ()
 {-# INLINE foldM'_ #-}
-foldM'_ = G.foldM'_
+foldM'_ f s v = phony $ proxyFW (G.foldM'_ f s) v
 
 -- | /O(n)/ Monadic fold over non-empty vectors with strict accumulator
 -- that discards the result
 fold1M'_ :: (Monad m, VECTOR s ty a) => (a -> a -> m a) -> Vector s ty a -> m ()
 {-# INLINE fold1M'_ #-}
-fold1M'_ = G.fold1M'_
+fold1M'_ f v = phony $ proxyFW (G.fold1M'_ f) v
 
 -- Prefix sums (scans)
 -- -------------------
@@ -1346,12 +1434,12 @@ fold1M'_ = G.fold1M'_
 --
 prescanl :: (VECTOR s ty a, VECTOR s ty b) => (a -> b -> a) -> a -> Vector s ty b -> Vector s ty a
 {-# INLINE prescanl #-}
-prescanl = G.prescanl
+prescanl f s v = phony $ unW . proxyFW (G.prescanl f s) v
 
 -- | /O(n)/ Prescan with strict accumulator
 prescanl' :: (VECTOR s ty a, VECTOR s ty b) => (a -> b -> a) -> a -> Vector s ty b -> Vector s ty a
 {-# INLINE prescanl' #-}
-prescanl' = G.prescanl'
+prescanl' f s v = phony $ unW . proxyFW (G.prescanl' f s) v
 
 -- | /O(n)/ Scan
 --
@@ -1363,12 +1451,12 @@ prescanl' = G.prescanl'
 --
 postscanl :: (VECTOR s ty a, VECTOR s ty b) => (a -> b -> a) -> a -> Vector s ty b -> Vector s ty a
 {-# INLINE postscanl #-}
-postscanl = G.postscanl
+postscanl f s v = phony $ unW . proxyFW (G.postscanl f s) v
 
 -- | /O(n)/ Scan with strict accumulator
 postscanl' :: (VECTOR s ty a, VECTOR s ty b) => (a -> b -> a) -> a -> Vector s ty b -> Vector s ty a
 {-# INLINE postscanl' #-}
-postscanl' = G.postscanl'
+postscanl' f s v = phony $ unW . proxyFW (G.postscanl' f s) v
 
 -- | /O(n)/ Haskell-style scan
 --
@@ -1380,12 +1468,12 @@ postscanl' = G.postscanl'
 --
 scanl :: (VECTOR s ty a, VECTOR s ty b) => (a -> b -> a) -> a -> Vector s ty b -> Vector s ty a
 {-# INLINE scanl #-}
-scanl = G.scanl
+scanl f s v = phony $ unW . proxyFW (G.scanl f s) v
 
 -- | /O(n)/ Haskell-style scan with strict accumulator
 scanl' :: (VECTOR s ty a, VECTOR s ty b) => (a -> b -> a) -> a -> Vector s ty b -> Vector s ty a
 {-# INLINE scanl' #-}
-scanl' = G.scanl'
+scanl' f s v = phony $ unW . proxyFW (G.scanl' f s) v
 
 -- | /O(n)/ Scan over a non-empty vector
 --
@@ -1395,12 +1483,12 @@ scanl' = G.scanl'
 --
 scanl1 :: VECTOR s ty a => (a -> a -> a) -> Vector s ty a -> Vector s ty a
 {-# INLINE scanl1 #-}
-scanl1 = G.scanl1
+scanl1 f v = phony $ unW . proxyFW (G.scanl1 f) v
 
 -- | /O(n)/ Scan over a non-empty vector with a strict accumulator
 scanl1' :: VECTOR s ty a => (a -> a -> a) -> Vector s ty a -> Vector s ty a
 {-# INLINE scanl1' #-}
-scanl1' = G.scanl1'
+scanl1' f v = phony $ unW . proxyFW (G.scanl1' f) v
 
 -- | /O(n)/ Right-to-left prescan
 --
@@ -1410,43 +1498,43 @@ scanl1' = G.scanl1'
 --
 prescanr :: (VECTOR s ty a, VECTOR s ty b) => (a -> b -> b) -> b -> Vector s ty a -> Vector s ty b
 {-# INLINE prescanr #-}
-prescanr = G.prescanr
+prescanr f s v = phony $ unW . proxyFW (G.prescanr f s) v
 
 -- | /O(n)/ Right-to-left prescan with strict accumulator
 prescanr' :: (VECTOR s ty a, VECTOR s ty b) => (a -> b -> b) -> b -> Vector s ty a -> Vector s ty b
 {-# INLINE prescanr' #-}
-prescanr' = G.prescanr'
+prescanr' f s v = phony $ unW . proxyFW (G.prescanr' f s) v
 
 -- | /O(n)/ Right-to-left scan
 postscanr :: (VECTOR s ty a, VECTOR s ty b) => (a -> b -> b) -> b -> Vector s ty a -> Vector s ty b
 {-# INLINE postscanr #-}
-postscanr = G.postscanr
+postscanr f s v = phony $ unW . proxyFW (G.postscanr f s) v
 
 -- | /O(n)/ Right-to-left scan with strict accumulator
 postscanr' :: (VECTOR s ty a, VECTOR s ty b) => (a -> b -> b) -> b -> Vector s ty a -> Vector s ty b
 {-# INLINE postscanr' #-}
-postscanr' = G.postscanr'
+postscanr' f s v = phony $ unW . proxyFW (G.postscanr' f s) v
 
 -- | /O(n)/ Right-to-left Haskell-style scan
 scanr :: (VECTOR s ty a, VECTOR s ty b) => (a -> b -> b) -> b -> Vector s ty a -> Vector s ty b
 {-# INLINE scanr #-}
-scanr = G.scanr
+scanr f s v = phony $ unW . proxyFW (G.scanr f s) v
 
 -- | /O(n)/ Right-to-left Haskell-style scan with strict accumulator
 scanr' :: (VECTOR s ty a, VECTOR s ty b) => (a -> b -> b) -> b -> Vector s ty a -> Vector s ty b
 {-# INLINE scanr' #-}
-scanr' = G.scanr'
+scanr' f s v = phony $ unW . proxyFW (G.scanr' f s) v
 
 -- | /O(n)/ Right-to-left scan over a non-empty vector
 scanr1 :: VECTOR s ty a => (a -> a -> a) -> Vector s ty a -> Vector s ty a
 {-# INLINE scanr1 #-}
-scanr1 = G.scanr1
+scanr1 f v = phony $ unW . proxyFW (G.scanr1 f) v
 
 -- | /O(n)/ Right-to-left scan over a non-empty vector with a strict
 -- accumulator
 scanr1' :: VECTOR s ty a => (a -> a -> a) -> Vector s ty a -> Vector s ty a
 {-# INLINE scanr1' #-}
-scanr1' = G.scanr1'
+scanr1' f v = phony $ unW . proxyFW (G.scanr1' f) v
 
 -- Conversions - Lists
 -- ------------------------
@@ -1454,21 +1542,21 @@ scanr1' = G.scanr1'
 -- | /O(n)/ Convert a vector to a list
 toList :: VECTOR s ty a => Vector s ty a -> [a]
 {-# INLINE toList #-}
-toList = G.toList
+toList v = phony $ proxyFW G.toList v
 
 -- | /O(n)/ Convert a list to a vector
-fromList :: VECTOR s ty a => [a] -> Vector s ty a
+fromList :: forall s ty a . VECTOR s ty a => [a] -> Vector s ty a
 {-# INLINE fromList #-}
-fromList xs = G.fromListN (Prelude.length xs) xs
+fromList xs = phony $ proxyW (G.fromListN (Prelude.length xs) xs)
 
 -- | /O(n)/ Convert the first @n@ elements of a list to a vector
 --
 -- @
 -- fromListN n xs = 'fromList' ('take' n xs)
 -- @
-fromListN :: VECTOR s ty a => Int -> [a] -> Vector s ty a
+fromListN :: forall s ty a . VECTOR s ty a => Int -> [a] -> Vector s ty a
 {-# INLINE fromListN #-}
-fromListN = G.fromListN
+fromListN i l = phony $ proxyW (G.fromListN i l)
 
 -- Conversions - Unsafe casts
 -- --------------------------
@@ -1478,53 +1566,49 @@ fromListN = G.fromListN
 
 -- | /O(1)/ Unsafe convert a mutable vector to an immutable one with
 -- copying. The mutable vector may not be used after this operation.
-unsafeFreeze
-        :: (VECTOR s ty a, PrimMonad m) => MVector s ty (PrimState m) a -> m (Vector s ty a)
+unsafeFreeze :: (VECTOR (Region m) ty a, MonadR m)
+             => MVector (Region m) ty a -> m (Vector (Region m) ty a)
 {-# INLINE unsafeFreeze #-}
-unsafeFreeze = G.unsafeFreeze
+unsafeFreeze m = withAcquire $ \p -> unW <$> G.unsafeFreeze (Mutable.withW p m)
 
 -- | /O(1)/ Unsafely convert an immutable vector to a mutable one with
 -- copying. The immutable vector may not be used after this operation.
-unsafeThaw
-        :: (VECTOR s ty a, PrimMonad m) => Vector s ty a -> m (MVector s ty (PrimState m) a)
+unsafeThaw :: (MonadR m, VECTOR (Region m) ty a)
+           => Vector (Region m) ty a -> m (MVector (Region m) ty a)
 {-# INLINE unsafeThaw #-}
-unsafeThaw = G.unsafeThaw
+unsafeThaw v = withAcquire $ \p -> Mutable.unW <$> G.unsafeThaw (withW p v)
 
 -- | /O(n)/ Yield a mutable copy of the immutable vector.
-thaw :: (VECTOR s ty a, PrimMonad m) => Vector s ty a -> m (MVector s ty (PrimState m) a)
+thaw :: (MonadR m, VECTOR (Region m) ty a)
+     => Vector (Region m) ty a -> m (MVector (Region m) ty a)
 {-# INLINE thaw #-}
-thaw = G.thaw
+thaw v1 = withAcquire $ \p -> Mutable.unW <$> G.thaw (withW p v1)
 
 -- | /O(n)/ Yield an immutable copy of the mutable vector.
-freeze :: (VECTOR s ty a, PrimMonad m) => MVector s ty (PrimState m) a -> m (Vector s ty a)
+freeze :: (MonadR m, VECTOR (Region m) ty a)
+       => MVector (Region m) ty a -> m (Vector (Region m) ty a)
 {-# INLINE freeze #-}
-freeze = G.freeze
+freeze m1 = withAcquire $ \p -> unW <$> G.freeze (Mutable.withW p m1)
 
 -- | /O(n)/ Copy an immutable vector into a mutable one. The two vectors must
 -- have the same length. This is not checked.
 unsafeCopy
-  :: (VECTOR s ty a, PrimMonad m) => MVector s ty (PrimState m) a -> Vector s ty a -> m ()
+  :: (MonadR m, VECTOR (Region m) ty a)
+  => MVector (Region m) ty a -> Vector (Region m) ty a -> m ()
 {-# INLINE unsafeCopy #-}
-unsafeCopy = G.unsafeCopy
+unsafeCopy m1 v2 = withAcquire $ \p -> G.unsafeCopy (Mutable.withW p m1) (withW p v2)
 
 -- | /O(n)/ Copy an immutable vector into a mutable one. The two vectors must
 -- have the same length.
-copy :: (VECTOR s ty a, PrimMonad m) => MVector s ty (PrimState m) a -> Vector s ty a -> m ()
+copy :: (MonadR m, VECTOR (Region m) ty a)
+     => MVector (Region m) ty a -> Vector (Region m) ty a -> m ()
 {-# INLINE copy #-}
-copy = G.copy
+copy m1 v2 = withAcquire $ \p -> G.copy (Mutable.withW p m1) (withW p v2)
 
--- | O(1) Inplace convertion to Storable vector.
-unsafeToStorable :: VECTOR s ty a
-                 => Vector s ty a         -- ^ target
-                 -> Storable.Vector a     -- ^ source
-{-# INLINE unsafeToStorable #-}
-unsafeToStorable v = unsafeInlineIO $
-  G.unsafeFreeze =<< Mutable.unsafeToStorable =<< G.unsafeThaw v
-
--- | O(N) Convertion from storable vector to SEXP vector.
-fromStorable :: VECTOR s ty a
-             => Storable.Vector a
-             -> Vector s ty a
-{-# INLINE fromStorable #-}
-fromStorable v = unsafeInlineIO $
-  G.unsafeFreeze =<< Mutable.fromStorable =<< G.unsafeThaw v
+phony :: (forall t . Reifies t (AcquireIO s) => Proxy t -> r) -> r
+phony f = reify (AcquireIO acquireIO) $ \p ->  f p
+  where
+    acquireIO :: SEXP V ty -> IO (SEXP g ty)
+    acquireIO x = do
+      R.preserveObject x
+      return $ R.unsafeRelease x

--- a/inline-r/src/Data/Vector/SEXP.chs
+++ b/inline-r/src/Data/Vector/SEXP.chs
@@ -420,7 +420,7 @@ unsafeToPtr v = unsafeInlineIO $ withForeignSEXP1 (vectorBase v) $ \p ->
 -- | /O(n)/ Create an immutable vector from a 'SEXP'. Because 'SEXP's are
 -- mutable, this function yields an immutable /copy/ of the 'SEXP'.
 fromSEXP :: (VECTOR s ty a) => SEXP s ty -> Vector s ty a
-fromSEXP s = phony $ \p -> runST $ do w <- run (proxyFW G.clone (unsafeFromSEXP s) p) 
+fromSEXP s = phony $ \p -> runST $ do w <- run (proxyFW G.clone (unsafeFromSEXP s) p)
                                       v <- G.unsafeFreeze w
                                       return (unW v)
 
@@ -456,7 +456,7 @@ toString v = unsafeInlineIO $
 
 -- | /O(n)/ Convert a character vector into a strict 'ByteString'.
 toByteString :: Vector s 'Char Word8 -> ByteString
-toByteString v = unsafeInlineIO $ 
+toByteString v = unsafeInlineIO $
    B.packCStringLen ( castPtr $ unsafeToPtr v
                     , fromIntegral $ vectorLength v)
 
@@ -774,7 +774,7 @@ infixr 5 ++
 -- | /O(m+n)/ Concatenate two vectors
 (++) :: VECTOR s ty a => Vector s ty a -> Vector s ty a -> Vector s ty a
 {-# INLINE (++) #-}
-v1 ++ v2 = phony $ unW . proxyFW2 (G.++) v1 v2 
+v1 ++ v2 = phony $ unW . proxyFW2 (G.++) v1 v2
 
 -- | /O(n)/ Concatenate all vectors in the list
 concat :: VECTOR s ty a => [Vector s ty a] -> Vector s ty a

--- a/inline-r/src/Data/Vector/SEXP.chs
+++ b/inline-r/src/Data/Vector/SEXP.chs
@@ -279,7 +279,7 @@ import qualified Data.ByteString as B
 import Control.Applicative hiding (empty)
 import Control.Monad.Primitive ( unsafeInlineIO, unsafePrimToPrim )
 import Data.Word ( Word8 )
-import Foreign ( Ptr, plusPtr, castPtr, peekElemOff )
+import Foreign ( Storable, Ptr, castPtr, peekElemOff )
 import Foreign.ForeignPtr (ForeignPtr, withForeignPtr)
 import Foreign.Marshal.Array ( copyArray )
 import qualified GHC.Foreign as GHC
@@ -412,10 +412,10 @@ instance VECTOR s ty a => Exts.IsList (Vector s ty a) where
 #endif
 
 -- | Return Pointer of the first element of the vector storage.
-unsafeToPtr :: Vector s ty a -> Ptr a
+unsafeToPtr :: Storable a => Vector s ty a -> Ptr a
 {-# INLINE unsafeToPtr #-}
-unsafeToPtr v = unsafeInlineIO $ withForeignSEXP1 (vectorBase v) $ \p ->
-   return $  (R.unsafeSEXPToVectorPtr p `plusPtr` (fromIntegral $ vectorOffset v))
+unsafeToPtr (Vector fp off len) = unsafeInlineIO $ withForeignSEXP1 fp $ \sx ->
+    return $ Mutable.unsafeToPtr $ Mutable.MVector sx off len
 
 -- | /O(n)/ Create an immutable vector from a 'SEXP'. Because 'SEXP's are
 -- mutable, this function yields an immutable /copy/ of the 'SEXP'.

--- a/inline-r/src/Data/Vector/SEXP/Base.hs
+++ b/inline-r/src/Data/Vector/SEXP/Base.hs
@@ -20,16 +20,16 @@ import Foreign.Storable (Storable)
 
 -- | Function from R types to the types of the representations of each element
 -- in the vector.
-type family ElemRep s (a :: SEXPTYPE)
-type instance ElemRep s 'Char    = Word8
-type instance ElemRep s 'Logical = Logical
-type instance ElemRep s 'Int     = Int32
-type instance ElemRep s 'Real    = Double
-type instance ElemRep s 'Complex = Complex Double
-type instance ElemRep s 'String  = SEXP s 'Char
-type instance ElemRep s 'Vector  = SomeSEXP s
-type instance ElemRep s 'Expr    = SomeSEXP s
-type instance ElemRep s 'Raw     = Word8
+type family ElemRep s (a :: SEXPTYPE) where
+  ElemRep s 'Char    = Word8
+  ElemRep s 'Logical = Logical
+  ElemRep s 'Int     = Int32
+  ElemRep s 'Real    = Double
+  ElemRep s 'Complex = Complex Double
+  ElemRep s 'String  = SEXP s 'Char
+  ElemRep s 'Vector  = SomeSEXP s
+  ElemRep s 'Expr    = SomeSEXP s
+  ElemRep s 'Raw     = Word8
 
 -- | 'ElemRep' in the form of a relation, for convenience.
 type E s a b = ElemRep s a ~ b

--- a/inline-r/src/Data/Vector/SEXP/Base.hs
+++ b/inline-r/src/Data/Vector/SEXP/Base.hs
@@ -8,6 +8,8 @@
 
 module Data.Vector.SEXP.Base where
 
+import Control.Memory.Region
+
 import Foreign.R.Type
 import Foreign.R (SEXP, SomeSEXP)
 
@@ -36,3 +38,6 @@ type E s a b = ElemRep s a ~ b
 
 -- | Constraint synonym for all operations on vectors.
 type VECTOR s ty a = (Storable a, IsVector ty, SingI ty, ElemRep s ty ~ a)
+
+-- | Constraint synonym for all operations on vectors.
+type SVECTOR ty a = (Storable a, IsVector ty, SingI ty, ElemRep V ty ~ a)

--- a/inline-r/src/Data/Vector/SEXP/Mutable.chs
+++ b/inline-r/src/Data/Vector/SEXP/Mutable.chs
@@ -87,6 +87,8 @@ import Control.Applicative
 import Control.Arrow ((>>>), (***))
 import Data.Proxy (Proxy(..))
 import Data.Reflection (Reifies(..), reify)
+import Foreign.C
+import Foreign.Storable (peekByteOff)
 import System.IO.Unsafe (unsafePerformIO)
 
 import Prelude hiding

--- a/inline-r/src/Data/Vector/SEXP/Mutable.chs
+++ b/inline-r/src/Data/Vector/SEXP/Mutable.chs
@@ -28,6 +28,7 @@ module Data.Vector.SEXP.Mutable
     MVector
   , fromSEXP
   , toSEXP
+  , release
     -- * Accessors
     -- ** Length information
   , length

--- a/inline-r/src/Data/Vector/SEXP/Mutable.chs
+++ b/inline-r/src/Data/Vector/SEXP/Mutable.chs
@@ -29,6 +29,7 @@ module Data.Vector.SEXP.Mutable
   , fromSEXP
   , toSEXP
   , release
+  , unsafeRelease
     -- * Accessors
     -- ** Length information
   , length
@@ -86,8 +87,6 @@ import Control.Applicative
 import Control.Arrow ((>>>), (***))
 import Data.Proxy (Proxy(..))
 import Data.Reflection (Reifies(..), reify)
-import Foreign.C
-import Foreign.Storable
 import System.IO.Unsafe (unsafePerformIO)
 
 import Prelude hiding

--- a/inline-r/src/Data/Vector/SEXP/Mutable.chs
+++ b/inline-r/src/Data/Vector/SEXP/Mutable.chs
@@ -1,36 +1,33 @@
 -- |
 -- Copyright: (C) 2013 Amgen, Inc.
+--                2016 Tweag I/O Limited.
 --
 -- Vectors that can be passed to and from R with no copying at all. These
 -- vectors are wrappers over SEXP vectors used by R. Memory for vectors is
 -- allocated from the R heap, and in such way that they can be converted to
 -- a 'SEXP' by simple pointer arithmetic (see 'toSEXP').
 --
--- The main difference between "Data.Vector.SEXP.Mutable" and
--- "Data.Vector.Storable" is that the former uses a header-prefixed data layout
--- (the header immediately precedes the payload of the vector). This means that
--- no additional pointer dereferencing is needed to reach the vector data. The
--- trade-off is, for mutable vectors, slicing is not supported. The reason is
--- that slicing header-prefixed vectors is generally not possible without
--- copying, which breaks the semantics of the API for 'MVector'.
---
--- To perform slicing, it is necessary to convert to a "Data.Vector.Storable"
--- vector first, using 'unsafeToStorable'.
+-- Like "Data.Vector.Storable.Mutable" vectors, the vector type in this module
+-- adds one extra level of indirection and a small amount of storage overhead
+-- for maintainging lengths and slice offsets. If you're keeping a very large
+-- number of tiny vectors in memory, you're better off keeping them as 'SEXP's
+-- and calling 'fromSEXP' on-the-fly.
 
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Data.Vector.SEXP.Mutable
-  ( -- * Mutable vectors of 'SEXP' types
-    MVector(..)
-  , IOVector
-  , STVector
+  ( -- * Mutable slices of 'SEXP' vector types
+    MVector
+  , fromSEXP
+  , toSEXP
     -- * Accessors
     -- ** Length information
   , length
@@ -42,6 +39,20 @@ module Data.Vector.SEXP.Mutable
   , replicate
   , replicateM
   , clone
+    -- ** Extracting subvectors
+  , slice
+  , init
+  , tail
+  , take
+  , drop
+  , splitAt
+  , unsafeSlice
+  , unsafeInit
+  , unsafeTail
+  , unsafeTake
+  , unsafeDrop
+    -- ** Overlapping
+  , overlaps
     -- ** Restricting memory usage
   , clear
     -- * Accessing individual elements
@@ -58,228 +69,269 @@ module Data.Vector.SEXP.Mutable
   , move
   , unsafeCopy
   , unsafeMove
-    -- * SEXP specific.
-  , fromSEXP
-  , toSEXP
-  , unsafeToStorable
-  , fromStorable
   ) where
 
+import Control.Monad.R.Class
+import Control.Monad.R.Internal
 import Data.Vector.SEXP.Base
+import Data.Vector.SEXP.Mutable.Internal
 import qualified Foreign.R as R
-import Foreign.R (SEXP, SEXPTYPE)
-import Foreign.R.Type (SSEXPTYPE, IsVector)
+import Foreign.R (SEXP)
 import Internal.Error
 
-import Control.Applicative
-import Control.Monad (liftM)
-import Control.Monad.Primitive
-  (PrimMonad, PrimState, RealWorld, unsafePrimToPrim, unsafeInlineIO)
 import qualified Data.Vector.Generic.Mutable as G
-import qualified Data.Vector.Storable.Mutable as Storable
-import Data.Singletons (fromSing, sing)
-import Data.Int
 
-import Foreign (castPtr, Ptr, withForeignPtr)
-import Foreign.Concurrent (newForeignPtr)
+import Control.Applicative
+import Control.Arrow ((>>>), (***))
+import Data.Proxy (Proxy(..))
+import Data.Reflection (Reifies(..), reify)
 import Foreign.C
 import Foreign.Storable
-import Foreign.Marshal.Array (copyArray, moveArray)
-
-import Prelude hiding (length, null, replicate, read)
 import System.IO.Unsafe (unsafePerformIO)
+
+import Prelude hiding
+  ( length, drop, init, null, read, replicate, splitAt, tail, take )
 
 #include <R.h>
 #define USE_RINTERNALS
 #include <Rinternals.h>
 
--- | Mutable R vector. They are represented in memory with the same header as
--- 'SEXP' nodes. The second type paramater is a phantom parameter reflecting at
--- the type level the tag of the vector when viewed as a 'SEXP'. The tag of the
--- vector and the representation type are related via 'ElemRep'.
-newtype MVector s (ty :: SEXPTYPE) r a = MVector { unMVector :: SEXP s ty }
+-- Internal helpers
+-- ----------------
 
-type IOVector s ty   = MVector s ty RealWorld
-type STVector s ty r = MVector s ty s
+phony
+  :: forall s ty a b.
+     (VECTOR s ty a)
+  => (forall t. Reifies t (AcquireIO s) => W t ty s a -> b)
+  -> MVector s ty a
+  -> b
+phony f v =
+    reify (AcquireIO acquireIO) $ \(Proxy :: Proxy t) -> do
+      f (W v :: W t ty s a)
+  where
+    acquireIO = violation "phony" "phony acquire called."
 
-instance (VECTOR s ty a)
-         => G.MVector (MVector s ty) a where
-  basicLength (MVector s) = unsafeInlineIO $
-    fromIntegral <$> {# get VECSEXP->vecsxp.length #} (R.unsexp s)
--- N.B. slicing can't be supported properly by vectors prefixed by header,
--- this means that we can support only a reducing size (required for
--- vectors algorithms), and slicing that is noop
-  basicUnsafeSlice j m v
-    | j == 0 && m == G.basicLength v = v
-    | j == 0 = unsafePerformIO $ do
-        let s = castPtr $ R.unsexp $ unMVector v
-        {# set VECSEXP->vecsxp.length #} s (fromIntegral m :: CInt)
-        return v
-    | otherwise =
-      failure "Data.Vector.SEXP.Mutable.slice"
-              "unsafeSlice is not supported for SEXP vectors, to perform slicing convert vector to Storable."
-  basicOverlaps mv1 mv2   = unMVector mv1 == unMVector mv2
-  basicUnsafeNew n
-    -- R calls using allocVector() for CHARSXP "defunct"...
-    | fromSing (sing :: SSEXPTYPE ty) == R.Char =
-      failure "Data.Vector.SEXP.Mutable.new"
-              "R character vectors are immutable and globally cached. Use 'mkChar' instead."
-    | otherwise =
-      -- No functor instance available here in GHC < 7.10 (pre AMP).
-      liftM fromSEXP $ unsafePrimToPrim (R.allocVectorProtected (sing :: SSEXPTYPE ty) n)
-  basicUnsafeRead mv i     = unsafePrimToPrim
-                           $ peekElemOff (toVecPtr mv) i
-  basicUnsafeWrite mv i x  = unsafePrimToPrim
-                           $ pokeElemOff (toVecPtr mv) i x
-  basicSet mv x            = Prelude.mapM_ (\i -> G.basicUnsafeWrite mv i x) [0..G.basicLength mv]
-  basicUnsafeCopy mv1 mv2  = unsafePrimToPrim $ do
-      copyArray (toVecPtr mv1)
-                (toVecPtr mv2)
-                (G.basicLength mv1)
-  basicUnsafeMove mv1 mv2  = unsafePrimToPrim $ do
-      moveArray (toVecPtr mv1)
-                (toVecPtr mv2)
-                (G.basicLength mv1)
+phony2
+  :: forall s ty a b.
+     (VECTOR s ty a)
+  => (forall t. Reifies t (AcquireIO s) => W t ty s a -> W t ty s a -> b)
+  -> MVector s ty a
+  -> MVector s ty a
+  -> b
+phony2 f v1 v2 =
+    reify (AcquireIO acquireIO) $ \(Proxy :: Proxy t) -> do
+      f (W $ v1 :: W t ty s a)
+        (W $ v2 :: W t ty s a)
+  where
+    acquireIO = violation "phony2" "phony acquire called."
 
-toVecPtr :: MVector s ty r a -> Ptr a
-toVecPtr mv = castPtr (R.unsafeSEXPToVectorPtr $ unMVector mv)
+-- Conversions
+-- -----------
 
 -- | /O(1)/ Create a vector from a 'SEXP'.
-fromSEXP :: (E s ty a, Storable a, IsVector ty)
-         => R.SEXP s ty
-         -> MVector s ty r a
-fromSEXP s = MVector s
+fromSEXP :: VECTOR s ty a => SEXP s ty -> MVector s ty a
+fromSEXP sx =
+    MVector sx 0 $ unsafePerformIO $ do
+      fromIntegral <$> {# get VECSEXP->vecsxp.length #} (R.unsexp sx)
 
--- | /O(1)/ Convert a mutable vector to a 'SEXP'. This can be done efficiently,
--- without copy, because vectors in this module always include a 'SEXP' header
--- immediately before the vector data in memory.
-toSEXP :: forall s a r ty. (E s ty a, IsVector ty, Storable a)
-       => MVector s ty r a
-       -> R.SEXP s ty
-toSEXP = unMVector
+-- | /O(1)/ in the common case, /O(n)/ for proper slices. Convert a mutable
+-- vector to a 'SEXP'. This can be done efficiently, without copy, because
+-- vectors in this module always include a 'SEXP' header immediately before the
+-- vector data in memory.
+toSEXP
+  :: (MonadR m, VECTOR (Region m) ty a)
+  => MVector (Region m) ty a
+  -> m (SEXP (Region m) ty)
+toSEXP (MVector sx 0 len)
+  | len == sexplen = return sx
+  where
+    sexplen = unsafePerformIO $ do
+      fromIntegral <$> {# get VECSEXP->vecsxp.length #} (R.unsexp sx)
+toSEXP v = toSEXP =<< clone v -- yield a zero based slice.
 
 -- Length information
 -- ------------------
 
 -- | Length of the mutable vector.
-length :: VECTOR s ty a => MVector s ty r a -> Int
+length :: VECTOR s ty a => MVector s ty a -> Int
 {-# INLINE length #-}
-length (MVector s) =
-    unsafeInlineIO $
-    fromIntegral <$> {# get VECSEXP->vecsxp.length #} (R.unsexp s)
+length = phony G.length
 
--- | Check whether the vector is empty
-null :: VECTOR s ty a => (MVector s ty) r a -> Bool
+-- | Check whether the vector is empty.
+null :: VECTOR s ty a => MVector s ty a -> Bool
 {-# INLINE null #-}
-null (MVector s) =
-    unsafeInlineIO $
-    ((/= (0::Int)) . fromIntegral) <$>
-    {# get VECSEXP->vecsxp.length #} (R.unsexp s)
+null = phony G.null
+
+-- Extracting subvectors
+-- ---------------------
+
+-- | Yield a part of the mutable vector without copying it.
+slice :: VECTOR s ty a => Int -> Int -> MVector s ty a -> MVector s ty a
+{-# INLINE slice #-}
+slice i j = phony (unW . G.slice i j)
+
+take :: VECTOR s ty a => Int -> MVector s ty a -> MVector s ty a
+{-# INLINE take #-}
+take n = phony (unW . G.take n)
+
+drop :: VECTOR s ty a => Int -> MVector s ty a -> MVector s ty a
+{-# INLINE drop #-}
+drop n = phony (unW . G.drop n)
+
+splitAt :: VECTOR s ty a => Int -> MVector s ty a -> (MVector s ty a, MVector s ty a)
+{-# INLINE splitAt #-}
+splitAt n = phony (G.splitAt n >>> unW *** unW)
+
+init :: VECTOR s ty a => MVector s ty a -> MVector s ty a
+{-# INLINE init #-}
+init = phony (unW . G.init)
+
+tail :: VECTOR s ty a => MVector s ty a -> MVector s ty a
+{-# INLINE tail #-}
+tail = phony (unW . G.tail)
+
+-- | Yield a part of the mutable vector without copying it. No bounds checks
+-- are performed.
+unsafeSlice :: VECTOR s ty a
+            => Int  -- ^ starting index
+            -> Int  -- ^ length of the slice
+            -> MVector s ty a
+            -> MVector s ty a
+{-# INLINE unsafeSlice #-}
+unsafeSlice i j = phony (unW . G.unsafeSlice i j)
+
+unsafeTake :: VECTOR s ty a => Int -> MVector s ty a -> MVector s ty a
+{-# INLINE unsafeTake #-}
+unsafeTake n = phony (unW . G.unsafeTake n)
+
+unsafeDrop :: VECTOR s ty a => Int -> MVector s ty a -> MVector s ty a
+{-# INLINE unsafeDrop #-}
+unsafeDrop n = phony (unW . G.unsafeDrop n)
+
+unsafeInit :: VECTOR s ty a => MVector s ty a -> MVector s ty a
+{-# INLINE unsafeInit #-}
+unsafeInit = phony (unW . G.unsafeInit)
+
+unsafeTail :: VECTOR s ty a => MVector s ty a -> MVector s ty a
+{-# INLINE unsafeTail #-}
+unsafeTail = phony (unW . G.unsafeTail)
+
+-- Overlapping
+-- -----------
+
+-- | Check whether two vectors overlap.
+overlaps :: VECTOR s ty a => MVector s ty a -> MVector s ty a -> Bool
+{-# INLINE overlaps #-}
+overlaps = phony2 G.overlaps
 
 -- Initialisation
 -- --------------
 
 -- | Create a mutable vector of the given length.
-new :: (PrimMonad m, VECTOR s ty a) => Int -> m (MVector s ty (PrimState m) a)
+new :: forall m ty a.
+       (MonadR m, VECTOR (Region m) ty a)
+    => Int
+    -> m (MVector (Region m) ty a)
 {-# INLINE new #-}
-new = G.new
+new n = withAcquire $ proxyW $ G.new n
 
 -- | Create a mutable vector of the given length. The length is not checked.
-unsafeNew :: (PrimMonad m, VECTOR s ty a) => Int -> m (MVector s ty (PrimState m) a)
+unsafeNew :: (MonadR m, VECTOR (Region m) ty a) => Int -> m (MVector (Region m) ty a)
 {-# INLINE unsafeNew #-}
-unsafeNew = G.unsafeNew
+unsafeNew n = withAcquire $ proxyW $ G.unsafeNew n
 
 -- | Create a mutable vector of the given length (0 if the length is negative)
 -- and fill it with an initial value.
-replicate :: (PrimMonad m, VECTOR s ty a) => Int -> a -> m (MVector s ty (PrimState m) a)
+replicate :: (MonadR m, VECTOR (Region m) ty a) => Int -> a -> m (MVector (Region m) ty a)
 {-# INLINE replicate #-}
-replicate = G.replicate
+replicate n x = withAcquire $ proxyW $ G.replicate n x
 
 -- | Create a mutable vector of the given length (0 if the length is negative)
 -- and fill it with values produced by repeatedly executing the monadic action.
-replicateM :: (PrimMonad m, VECTOR s ty a) => Int -> m a -> m (MVector s ty (PrimState m) a)
+replicateM :: (MonadR m, VECTOR (Region m) ty a) => Int -> m a -> m (MVector (Region m) ty a)
 {-# INLINE replicateM #-}
-replicateM = G.replicateM
+replicateM n m = withAcquire $ proxyW $ G.replicateM n m
 
 -- | Create a copy of a mutable vector.
-clone :: (PrimMonad m, VECTOR s ty a)
-      => MVector s ty (PrimState m) a -> m (MVector s ty (PrimState m) a)
+clone :: (MonadR m, VECTOR (Region m) ty a)
+      => MVector (Region m) ty a
+      -> m (MVector (Region m) ty a)
 {-# INLINE clone #-}
-clone = G.clone
+clone v = withAcquire $ proxyW $ G.clone (W v)
 
 -- Restricting memory usage
 -- ------------------------
 
 -- | Reset all elements of the vector to some undefined value, clearing all
 -- references to external objects. This is usually a noop for unboxed vectors.
-clear :: (PrimMonad m, VECTOR s ty a) => MVector s ty (PrimState m) a -> m ()
+clear :: (MonadR m, VECTOR (Region m) ty a) => MVector (Region m) ty a -> m ()
 {-# INLINE clear #-}
-clear = G.clear
+clear v = withAcquire $ \p -> G.clear (withW p v)
 
 -- Accessing individual elements
 -- -----------------------------
 
 -- | Yield the element at the given position.
-read :: (PrimMonad m, VECTOR s ty a)
-     => MVector s ty (PrimState m) a -> Int -> m a
+read :: (MonadR m, VECTOR (Region m) ty a)
+     => MVector (Region m) ty a -> Int -> m a
 {-# INLINE read #-}
-read = G.read
+read v i = withAcquire $ \p -> G.read (withW p v) i
 
 -- | Replace the element at the given position.
-write :: (PrimMonad m, VECTOR s ty a)
-      => MVector s ty (PrimState m) a -> Int -> a -> m ()
+write :: (MonadR m, VECTOR (Region m) ty a)
+      => MVector (Region m) ty a -> Int -> a -> m ()
 {-# INLINE write #-}
-write = G.write
+write v i x = withAcquire $ \p -> G.write (withW p v) i x
 
 -- | Swap the elements at the given positions.
-swap :: (PrimMonad m, VECTOR s ty a)
-     => MVector s ty (PrimState m) a -> Int -> Int -> m ()
+swap :: (MonadR m, VECTOR (Region m) ty a)
+     => MVector (Region m) ty a -> Int -> Int -> m ()
 {-# INLINE swap #-}
-swap = G.swap
+swap v i j = withAcquire $ \p -> G.swap (withW p v) i j
 
 -- | Yield the element at the given position. No bounds checks are performed.
-unsafeRead :: (PrimMonad m, VECTOR s ty a)
-           => MVector s ty (PrimState m) a -> Int -> m a
+unsafeRead :: (MonadR m, VECTOR (Region m) ty a)
+           => MVector (Region m) ty a -> Int -> m a
 {-# INLINE unsafeRead #-}
-unsafeRead = G.unsafeRead
+unsafeRead v i = withAcquire $ \p -> G.unsafeRead (withW p v) i
 
 -- | Replace the element at the given position. No bounds checks are performed.
-unsafeWrite :: (PrimMonad m, VECTOR s ty a)
-            => MVector s ty (PrimState m) a -> Int -> a -> m ()
+unsafeWrite :: (MonadR m, VECTOR (Region m) ty a)
+            => MVector (Region m) ty a -> Int -> a -> m ()
 {-# INLINE unsafeWrite #-}
-unsafeWrite = G.unsafeWrite
+unsafeWrite v i x = withAcquire $ \p -> G.unsafeWrite (withW p v) i x
 
 -- | Swap the elements at the given positions. No bounds checks are performed.
-unsafeSwap :: (PrimMonad m, VECTOR s ty a)
-           => MVector s ty (PrimState m) a -> Int -> Int -> m ()
+unsafeSwap :: (MonadR m, VECTOR (Region m) ty a)
+           => MVector (Region m) ty a -> Int -> Int -> m ()
 {-# INLINE unsafeSwap #-}
-unsafeSwap = G.unsafeSwap
+unsafeSwap v i j = withAcquire $ \p -> G.unsafeSwap (withW p v) i j
 
 -- Filling and copying
 -- -------------------
 
 -- | Set all elements of the vector to the given value.
-set :: (PrimMonad m, VECTOR s ty a) => MVector s ty (PrimState m) a -> a -> m ()
+set :: (MonadR m, VECTOR (Region m) ty a) => MVector (Region m) ty a -> a -> m ()
 {-# INLINE set #-}
-set = G.set
+set v x = withAcquire $ \p -> G.set (withW p v) x
 
 -- | Copy a vector. The two vectors must have the same length and may not
 -- overlap.
-copy :: (PrimMonad m, VECTOR s ty a)
-     => MVector s ty (PrimState m) a
-     -> MVector s ty (PrimState m) a
+copy :: (MonadR m, VECTOR (Region m) ty a)
+     => MVector (Region m) ty a
+     -> MVector (Region m) ty a
      -> m ()
 {-# INLINE copy #-}
-copy = G.copy
+copy v1 v2 = withAcquire $ \p -> G.copy (withW p v1) (withW p v2)
 
 -- | Copy a vector. The two vectors must have the same length and may not
 -- overlap. This is not checked.
-unsafeCopy :: (PrimMonad m, VECTOR s ty a)
-           => MVector s ty (PrimState m) a   -- ^ target
-           -> MVector s ty (PrimState m) a   -- ^ source
+unsafeCopy :: (MonadR m, VECTOR (Region m) ty a)
+           => MVector (Region m) ty a   -- ^ target
+           -> MVector (Region m) ty a   -- ^ source
            -> m ()
 {-# INLINE unsafeCopy #-}
-unsafeCopy = G.unsafeCopy
+unsafeCopy v1 v2 = withAcquire $ \p -> G.unsafeCopy (withW p v1) (withW p v2)
 
 -- | Move the contents of a vector. The two vectors must have the same
 -- length.
@@ -288,12 +340,12 @@ unsafeCopy = G.unsafeCopy
 -- Otherwise, the copying is performed as if the source vector were
 -- copied to a temporary vector and then the temporary vector was copied
 -- to the target vector.
-move :: (PrimMonad m, VECTOR s ty a)
-     => MVector s ty (PrimState m) a
-     -> MVector s ty (PrimState m) a
+move :: (MonadR m, VECTOR (Region m) ty a)
+     => MVector (Region m) ty a
+     -> MVector (Region m) ty a
      -> m ()
 {-# INLINE move #-}
-move = G.move
+move v1 v2 = withAcquire $ \p -> G.move (withW p v1) (withW p v2)
 
 -- | Move the contents of a vector. The two vectors must have the same
 -- length, but this is not checked.
@@ -302,31 +354,9 @@ move = G.move
 -- Otherwise, the copying is performed as if the source vector were
 -- copied to a temporary vector and then the temporary vector was copied
 -- to the target vector.
-unsafeMove :: (PrimMonad m, VECTOR s ty a)
-           => MVector s ty (PrimState m) a          -- ^ target
-           -> MVector s ty (PrimState m) a          -- ^ source
+unsafeMove :: (MonadR m, VECTOR (Region m) ty a)
+           => MVector (Region m) ty a             -- ^ target
+           -> MVector (Region m) ty a             -- ^ source
            -> m ()
 {-# INLINE unsafeMove #-}
-unsafeMove = G.unsafeMove
-
--- | O(1) Inplace convertion to Storable vector.
-unsafeToStorable :: (PrimMonad m, VECTOR s ty a)
-                 => MVector s ty (PrimState m) a           -- ^ target
-                 -> m (Storable.MVector (PrimState m) a) -- ^ source
-{-# INLINE unsafeToStorable #-}
-unsafeToStorable v@(MVector p) = unsafePrimToPrim $ do
-  R.preserveObject p
-  ptr <- newForeignPtr (toVecPtr v) (R.releaseObject (R.sexp $ castPtr $ toVecPtr v))
-  return $ Storable.unsafeFromForeignPtr0 ptr (length v)
-
--- | O(N) Convertion from storable vector to SEXP vector.
-fromStorable :: (PrimMonad m, VECTOR s ty a)
-             => Storable.MVector (PrimState m) a
-             -> m (MVector s ty (PrimState m) a)
-{-# INLINE fromStorable #-}
-fromStorable v = do
-  let (fptr, l) = Storable.unsafeToForeignPtr0 v
-  mv <- new l
-  unsafePrimToPrim $ withForeignPtr fptr $ \p -> do
-    copyArray (toVecPtr mv) p (Storable.length v)
-  return mv
+unsafeMove v1 v2 = withAcquire $ \p -> G.unsafeMove (withW p v1) (withW p v2)

--- a/inline-r/src/Data/Vector/SEXP/Mutable/Internal.hs
+++ b/inline-r/src/Data/Vector/SEXP/Mutable/Internal.hs
@@ -17,6 +17,7 @@ module Data.Vector.SEXP.Mutable.Internal
   , proxyW
   , unsafeToPtr
   , release
+  , unsafeRelease
   ) where
 
 import Control.Memory.Region
@@ -32,7 +33,6 @@ import qualified Data.Vector.Generic.Mutable as G
 import Data.Vector.SEXP.Base
 import Foreign (castPtr, Ptr)
 import Foreign.Marshal.Array (copyArray, moveArray)
-import qualified Foreign.R as R
 import Foreign.R (SEXP)
 import Foreign.R.Type (SSEXPTYPE)
 import Foreign.Storable
@@ -106,4 +106,7 @@ withW :: proxy t -> MVector s ty a -> W t ty s a
 withW _ v = W v
 
 release :: (g <= s) => MVector s ty a -> MVector g ty a
-release (MVector b o l) = MVector (R.release b) o l
+release = unsafeRelease
+
+unsafeRelease :: MVector s ty a -> MVector g ty a
+unsafeRelease (MVector b o l) = MVector (R.unsafeRelease b) o l

--- a/inline-r/src/Data/Vector/SEXP/Mutable/Internal.hs
+++ b/inline-r/src/Data/Vector/SEXP/Mutable/Internal.hs
@@ -57,7 +57,7 @@ instance (Reifies t (AcquireIO s), VECTOR s ty a) => G.MVector (W t ty) a where
   basicLength (unW -> MVector _ _ len) = fromIntegral len
 
   {-# INLINE basicUnsafeSlice #-}
-  basicUnsafeSlice j m (unW -> MVector ptr off len) =
+  basicUnsafeSlice j m (unW -> MVector ptr off _len) =
       W $ MVector ptr (off + fromIntegral j) (fromIntegral m)
 
   {-# INLINE basicOverlaps #-}

--- a/inline-r/src/Data/Vector/SEXP/Mutable/Internal.hs
+++ b/inline-r/src/Data/Vector/SEXP/Mutable/Internal.hs
@@ -105,8 +105,8 @@ proxyW m _ = fmap unW m
 withW :: proxy t -> MVector s ty a -> W t ty s a
 withW _ v = W v
 
-release :: (g <= s) => MVector s ty a -> MVector g ty a
+release :: (s' <= s) => MVector s ty a -> MVector s' ty a
 release = unsafeRelease
 
-unsafeRelease :: MVector s ty a -> MVector g ty a
+unsafeRelease :: MVector s ty a -> MVector s' ty a
 unsafeRelease (MVector b o l) = MVector (R.unsafeRelease b) o l

--- a/inline-r/src/Data/Vector/SEXP/Mutable/Internal.hs
+++ b/inline-r/src/Data/Vector/SEXP/Mutable/Internal.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE ViewPatterns #-}
 
@@ -14,7 +15,12 @@ module Data.Vector.SEXP.Mutable.Internal
   , W(..)
   , withW
   , proxyW
+  , unsafeToPtr
+  , release
   ) where
+
+import Control.Memory.Region
+import qualified Foreign.R as R
 
 import Control.Monad.Primitive (unsafePrimToPrim)
 import Control.Monad.R.Internal
@@ -98,3 +104,6 @@ proxyW m _ = fmap unW m
 
 withW :: proxy t -> MVector s ty a -> W t ty s a
 withW _ v = W v
+
+release :: (g <= s) => MVector s ty a -> MVector g ty a
+release (MVector b o l) = MVector (R.release b) o l

--- a/inline-r/src/Data/Vector/SEXP/Mutable/Internal.hs
+++ b/inline-r/src/Data/Vector/SEXP/Mutable/Internal.hs
@@ -1,0 +1,100 @@
+-- |
+-- Copyright: (C) 2016 Tweag I/O Limited.
+
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE ViewPatterns #-}
+
+module Data.Vector.SEXP.Mutable.Internal
+  ( MVector(..)
+  , W(..)
+  , withW
+  , proxyW
+  ) where
+
+import Control.Monad.Primitive (unsafePrimToPrim)
+import Control.Monad.R.Internal
+import Data.Int (Int32)
+import Data.Proxy (Proxy(..))
+import Data.Reflection (Reifies(..))
+import Data.Singletons (fromSing, sing)
+import qualified Data.Vector.Generic.Mutable as G
+import Data.Vector.SEXP.Base
+import Foreign (castPtr, Ptr)
+import Foreign.Marshal.Array (copyArray, moveArray)
+import qualified Foreign.R as R
+import Foreign.R (SEXP)
+import Foreign.R.Type (SSEXPTYPE)
+import Foreign.Storable
+import Internal.Error
+
+-- | Mutable R vector. Represented in memory with the same header as 'SEXP'
+-- nodes. The second type parameter is phantom, reflecting at the type level the
+-- tag of the vector when viewed as a 'SEXP'. The tag of the vector and the
+-- representation type are related via 'ElemRep'.
+data MVector s ty a = MVector
+  { mvectorBase :: {-# UNPACK #-} !(SEXP s ty)
+  , mvectorOffset :: {-# UNPACK #-} !Int32
+  , mvectorLength :: {-# UNPACK #-} !Int32
+  }
+
+-- | Internal wrapper type for reflection. First type parameter is the reified
+-- type to reflect.
+newtype W t ty s a = W { unW :: MVector s ty a }
+
+instance (Reifies t (AcquireIO s), VECTOR s ty a) => G.MVector (W t ty) a where
+  {-# INLINE basicLength #-}
+  basicLength (unW -> MVector _ _ len) = fromIntegral len
+
+  {-# INLINE basicUnsafeSlice #-}
+  basicUnsafeSlice j m (unW -> MVector ptr off len) =
+      W $ MVector ptr (off + fromIntegral j) (fromIntegral m)
+
+  {-# INLINE basicOverlaps #-}
+  basicOverlaps (unW -> MVector ptr1 off1 len1) (unW -> MVector ptr2 off2 len2) =
+      ptr1 == ptr2 && (off2 < off1 + len1 || off1 < off2 + len2)
+
+  {-# INLINE basicUnsafeNew #-}
+  basicUnsafeNew n
+    -- R calls using allocVector() for CHARSXP "defunct"...
+    | fromSing (sing :: SSEXPTYPE ty) == R.Char =
+      failure "Data.Vector.SEXP.Mutable.new"
+              "R character vectors are immutable and globally cached. Use 'mkChar' instead."
+    | otherwise = do
+      sx <- unsafePrimToPrim (acquireIO =<< R.allocVector (sing :: SSEXPTYPE ty) n)
+      return $ W $ MVector (R.unsafeRelease sx) 0 (fromIntegral n)
+    where
+      AcquireIO acquireIO = reflect (Proxy :: Proxy t)
+
+  {-# INLINE basicUnsafeRead #-}
+  basicUnsafeRead (unW -> mv) i =
+      unsafePrimToPrim $ peekElemOff (unsafeToPtr mv) i
+
+  {-# INLINE basicUnsafeWrite #-}
+  basicUnsafeWrite (unW -> mv) i x =
+      unsafePrimToPrim $ pokeElemOff (unsafeToPtr mv) i x
+
+  {-# INLINE basicUnsafeCopy #-}
+  basicUnsafeCopy w1@(unW -> mv1) (unW -> mv2) = unsafePrimToPrim $ do
+      copyArray (unsafeToPtr mv1)
+                (unsafeToPtr mv2)
+                (G.basicLength w1)
+
+  {-# INLINE basicUnsafeMove #-}
+  basicUnsafeMove w1@(unW -> mv1) (unW -> mv2)  = unsafePrimToPrim $ do
+      moveArray (unsafeToPtr mv1)
+                (unsafeToPtr mv2)
+                (G.basicLength w1)
+
+unsafeToPtr :: MVector s ty a -> Ptr a
+unsafeToPtr v = castPtr (R.unsafeSEXPToVectorPtr $ mvectorBase v)
+
+proxyW :: Monad m => m (W t ty s a) -> proxy t -> m (MVector s ty a)
+proxyW m _ = fmap unW m
+
+withW :: proxy t -> MVector s ty a -> W t ty s a
+withW _ v = W v

--- a/inline-r/src/Foreign/R.chs
+++ b/inline-r/src/Foreign/R.chs
@@ -517,7 +517,7 @@ allocVectorProtected ty n = fmap release (protect =<< allocVector ty n)
 {#fun R_PreserveObject as preserveObject { unsexp `SEXP s a' } -> `()' #}
 
 -- | Allow GC to remove an preserved object.
-{#fun R_ReleaseObject as releaseObject { unsexp `SEXP G a' } -> `()' #}
+{#fun R_ReleaseObject as releaseObject { unsexp `SEXP s a' } -> `()' #}
 
 --------------------------------------------------------------------------------
 -- Evaluation                                                                 --

--- a/inline-r/src/H/Prelude/Interactive.hs
+++ b/inline-r/src/H/Prelude/Interactive.hs
@@ -17,6 +17,7 @@ import qualified H.Prelude as H
 
 instance MonadR IO where
   io = id
+  unsafeToIO = id
 
 -- | A form of the 'print' function that is more convenient in an
 -- interactive session.

--- a/inline-r/src/H/Prelude/Interactive.hs
+++ b/inline-r/src/H/Prelude/Interactive.hs
@@ -4,6 +4,8 @@
 -- This class is not meant to be imported in any other circumstance than in
 -- a GHCi session.
 
+{-# LANGUAGE TypeFamilies #-}
+
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 module H.Prelude.Interactive
   ( module H.Prelude
@@ -17,7 +19,9 @@ import qualified H.Prelude as H
 
 instance MonadR IO where
   io = id
-  unsafeToIO = id
+  data ExecContext IO = ExecContext
+  getExecContext = return ExecContext
+  unsafeRunWithExecContext = const
 
 -- | A form of the 'print' function that is more convenient in an
 -- interactive session.

--- a/inline-r/src/Language/R.hs
+++ b/inline-r/src/Language/R.hs
@@ -57,11 +57,6 @@ import Prelude
 -- NOTE: In this module, cannot use quasiquotations, since we are lower down in
 -- the dependency hierarchy.
 
--- | Internal helper that shows that action is running inside 'Void' region.
-inVoid :: R V z -> R V z
-inVoid = id
-{-# INLINE inVoid #-}
-
 -- | Parse and then evaluate expression.
 parseEval :: ByteString -> IO (SomeSEXP V)
 parseEval txt = useAsCString txt $ \ctxt ->
@@ -70,7 +65,7 @@ parseEval txt = useAsCString txt $ \ctxt ->
       R.withProtected (R.parseVector rtxt 1 status (R.release nilValue)) $ \exprs -> do
         rc <- fromIntegral <$> peek status
         unless (R.PARSE_OK == toEnum rc) $
-          unsafeToIO $ inVoid $ throwRMessage $ "Parse error in: " ++ C8.unpack txt
+          runRegion $ throwRMessage $ "Parse error in: " ++ C8.unpack txt
         SomeSEXP expr <- peek $ castPtr $ R.unsafeSEXPToVectorPtr exprs
         runRegion $ do
           SomeSEXP val <- eval expr
@@ -121,7 +116,7 @@ evalEnv (hexp -> Expr _ v) rho = acquireSome =<< do
       x <- Prelude.last <$> forM (Vector.toList v) (\(SomeSEXP s) -> do
           z <- R.tryEvalSilent s rho p
           e <- peek p
-          when (e /= 0) $ unsafeToIO $ inVoid $ throwR rho
+          when (e /= 0) $ runRegion $ throwR rho
           return z)
       R.unprotect (Vector.length v)
       return x
@@ -129,7 +124,7 @@ evalEnv x rho = acquireSome =<< do
     io $ alloca $ \p -> R.withProtected (return (R.release x)) $ \_ -> do
       v <- R.tryEvalSilent x rho p
       e <- peek p
-      when (e /= 0) $ unsafeToIO $ inVoid $ throwR rho
+      when (e /= 0) $ runRegion $ throwR rho
       return v
 
 -- | Evaluate a (sequence of) expression(s) in the global environment.

--- a/inline-r/src/Language/R.hs
+++ b/inline-r/src/Language/R.hs
@@ -72,7 +72,9 @@ parseEval txt = useAsCString txt $ \ctxt ->
         unless (R.PARSE_OK == toEnum rc) $
           unsafeToIO $ inVoid $ throwRMessage $ "Parse error in: " ++ C8.unpack txt
         SomeSEXP expr <- peek $ castPtr $ R.unsafeSEXPToVectorPtr exprs
-        unsafeToIO $ inVoid $ eval expr
+        runRegion $ do
+          SomeSEXP val <- eval expr
+          return $ SomeSEXP (R.release val)
 
 -- | Parse file and perform some actions on parsed file.
 --

--- a/inline-r/src/Language/R/HExp.chs
+++ b/inline-r/src/Language/R/HExp.chs
@@ -74,6 +74,7 @@ import Data.Maybe (isJust)
 import Data.Type.Equality (TestEquality(..), (:~:)(Refl))
 import GHC.Ptr (Ptr(..))
 import Foreign.Storable
+import Foreign.C
 import Foreign (castPtr)
 import Unsafe.Coerce (unsafeCoerce)
 -- Fixes redundant import warning >= 7.10 without CPP

--- a/inline-r/src/Language/R/HExp.chs
+++ b/inline-r/src/Language/R/HExp.chs
@@ -74,8 +74,7 @@ import Data.Maybe (isJust)
 import Data.Type.Equality (TestEquality(..), (:~:)(Refl))
 import GHC.Ptr (Ptr(..))
 import Foreign.Storable
-import Foreign.C
-import Foreign ( castPtr )
+import Foreign (castPtr)
 import Unsafe.Coerce (unsafeCoerce)
 -- Fixes redundant import warning >= 7.10 without CPP
 import Prelude
@@ -483,17 +482,17 @@ unhexp s@(Promise{}) = io $
     withProtected (R.allocSEXP R.SPromise)
                   (\x -> poke (R.unSEXP x) s >> return x)
 unhexp  (Bytecode{}) = unimplemented "unhexp"
-unhexp (Real vt)     = io $ Vector.unsafeToSEXP vt
-unhexp (Logical vt)  = io $ Vector.unsafeToSEXP vt
-unhexp (Int vt)      = io $ Vector.unsafeToSEXP vt
-unhexp (Complex vt)  = io $ Vector.unsafeToSEXP vt
-unhexp (Vector _ vt) = io $ Vector.unsafeToSEXP vt
-unhexp (Char vt)     = io $ Vector.unsafeToSEXP vt
-unhexp (String vt)   = io $ Vector.unsafeToSEXP vt
-unhexp (Raw vt)      = io $ Vector.unsafeToSEXP vt
+unhexp (Real vt)     = return $ Vector.unsafeToSEXP vt
+unhexp (Logical vt)  = return $ Vector.unsafeToSEXP vt
+unhexp (Int vt)      = return $ Vector.unsafeToSEXP vt
+unhexp (Complex vt)  = return $ Vector.unsafeToSEXP vt
+unhexp (Vector _ vt) = return $ Vector.unsafeToSEXP vt
+unhexp (Char vt)     = return $ Vector.unsafeToSEXP vt
+unhexp (String vt)   = return $ Vector.unsafeToSEXP vt
+unhexp (Raw vt)      = return $ Vector.unsafeToSEXP vt
 unhexp S4{}          = unimplemented "unhexp"
-unhexp (Expr _ vt)   = io $ Vector.unsafeToSEXP vt
-unhexp WeakRef{}     = io $ error "unhexp does not support WeakRef, use Foreign.R.mkWeakRef instead."
+unhexp (Expr _ vt)   = return $ Vector.unsafeToSEXP vt
+unhexp WeakRef{}     = error "unhexp does not support WeakRef, use Foreign.R.mkWeakRef instead."
 unhexp DotDotDot{}   = unimplemented "unhexp"
 unhexp ExtPtr{}      = unimplemented "unhexp"
 

--- a/inline-r/src/Language/R/Instance.hs
+++ b/inline-r/src/Language/R/Instance.hs
@@ -28,6 +28,7 @@ module Language.R.Instance
   ( -- * The R monad
     R
   , runRegion
+  , unsafeRunRegion
   -- * R instance creation
   , Config(..)
   , defaultConfig
@@ -121,8 +122,11 @@ withEmbeddedR config = bracket_ (initialize config) finalize
 -- thunks hold onto resources in a way that would extrude the scope of the
 -- region. This means that the result must be first-order data (i.e. not
 -- a function).
-runRegion :: NFData a => (forall s . R s a) -> IO a
-runRegion r =
+runRegion :: NFData a => (forall s. R s a) -> IO a
+runRegion r = unsafeRunRegion r
+
+unsafeRunRegion :: NFData a => R s a -> IO a
+unsafeRunRegion r =
   bracket (newIORef 0)
           (R.unprotect <=< readIORef)
           (\d -> do

--- a/inline-r/src/Language/R/Instance.hs
+++ b/inline-r/src/Language/R/Instance.hs
@@ -97,9 +97,9 @@ instance MonadR (R s) where
     x <- R.release <$> R.protect s
     modifyIORef' cnt succ
     return x
-  unsafeToIO m = do
-    ref <- newIORef 0
-    runReaderT (unR m) ref
+  newtype ExecContext (R s) = ExecContext (IORef Int)
+  getExecContext = R $ ReaderT $ \ref -> return (ExecContext ref)
+  unsafeRunWithExecContext m (ExecContext ref) = runReaderT (unR m) ref
 
 -- | Initialize a new instance of R, execute actions that interact with the
 -- R instance and then finalize the instance. This is typically called at the

--- a/inline-r/src/Language/R/Instance.hs
+++ b/inline-r/src/Language/R/Instance.hs
@@ -28,7 +28,6 @@ module Language.R.Instance
   ( -- * The R monad
     R
   , runRegion
-  , unsafeRToIO
   -- * R instance creation
   , Config(..)
   , defaultConfig
@@ -97,6 +96,9 @@ instance MonadR (R s) where
     x <- R.release <$> R.protect s
     modifyIORef' cnt succ
     return x
+  unsafeToIO m = do
+    ref <- newIORef 0
+    runReaderT (unR m) ref
 
 -- | Initialize a new instance of R, execute actions that interact with the
 -- R instance and then finalize the instance. This is typically called at the
@@ -126,14 +128,6 @@ runRegion r =
           (\d -> do
              x <- runReaderT (unR r) d
              x `deepseq` return x)
-
--- | An unsafe version of 'runRegion', providing no static guarantees that
--- resources do not extrude the scope of their region. For internal use only.
-unsafeRToIO :: R s a -> IO a
-unsafeRToIO r =
-  bracket (newIORef 0)
-          (R.unprotect <=< readIORef)
-          (runReaderT (unR r))
 
 -- | Configuration options for the R runtime. Configurations form monoids, so
 -- arguments can be accumulated left-to-right through monoidal composition.

--- a/inline-r/src/Language/R/Internal.hs
+++ b/inline-r/src/Language/R/Internal.hs
@@ -1,27 +1,33 @@
 {-# LANGUAGE DataKinds #-}
 {-# Language ViewPatterns #-}
 
-module Language.R.Internal where
+module Language.R.Internal (r1, r2, installIO) where
 
 import           Control.Memory.Region
-import Foreign.R (SEXP, SomeSEXP(..))
+import           Control.Monad.R.Class
 import qualified Foreign.R as R
+import           Foreign.R (SEXP, SomeSEXP)
 import           Language.R
 
 import Data.ByteString as B
 import Foreign.C.String ( withCString )
 
+-- | Helper
+inVoid :: R V z -> R V z
+inVoid = id
+{-# INLINE inVoid #-}
+
 -- | Call a pure unary R function of the given name in the global environment.
 r1 :: ByteString -> SEXP s a -> IO (SomeSEXP V)
 r1 fn a =
     useAsCString fn $ \cfn -> R.install cfn >>= \f ->
-      R.withProtected (R.lang2 f (R.release a)) (unsafeRToIO . eval)
+      R.withProtected (R.lang2 f (R.release a)) (unsafeToIO . inVoid . eval)
 
 -- | Call a pure binary R function. See 'r1' for additional comments.
 r2 :: ByteString -> SEXP s a -> SEXP s b -> IO (SomeSEXP V)
 r2 fn a b =
     useAsCString fn $ \cfn -> R.install cfn >>= \f ->
-      R.withProtected (R.lang3 f (R.release a) (R.release b)) (unsafeRToIO . eval)
+      R.withProtected (R.lang3 f (R.release a) (R.release b)) (unsafeToIO . inVoid . eval)
 
 -- | Internalize a symbol name.
 installIO :: String -> IO (SEXP V 'R.Symbol)

--- a/inline-r/src/Language/R/Internal.hs
+++ b/inline-r/src/Language/R/Internal.hs
@@ -20,13 +20,13 @@ inVoid = id
 r1 :: ByteString -> SEXP s a -> IO (SomeSEXP V)
 r1 fn a =
     useAsCString fn $ \cfn -> R.install cfn >>= \f ->
-      R.withProtected (R.lang2 f (R.release a)) (unsafeToIO . inVoid . eval)
+      R.withProtected (R.lang2 f (R.release a)) (unsafeRunRegion . inVoid . eval)
 
 -- | Call a pure binary R function. See 'r1' for additional comments.
 r2 :: ByteString -> SEXP s a -> SEXP s b -> IO (SomeSEXP V)
 r2 fn a b =
     useAsCString fn $ \cfn -> R.install cfn >>= \f ->
-      R.withProtected (R.lang3 f (R.release a) (R.release b)) (unsafeToIO . inVoid . eval)
+      R.withProtected (R.lang3 f (R.release a) (R.release b)) (unsafeRunRegion . inVoid . eval)
 
 -- | Internalize a symbol name.
 installIO :: String -> IO (SEXP V 'R.Symbol)

--- a/inline-r/src/Language/R/Internal.hs
+++ b/inline-r/src/Language/R/Internal.hs
@@ -4,7 +4,6 @@
 module Language.R.Internal (r1, r2, installIO) where
 
 import           Control.Memory.Region
-import           Control.Monad.R.Class
 import qualified Foreign.R as R
 import           Foreign.R (SEXP, SomeSEXP)
 import           Language.R

--- a/inline-r/src/Language/R/Internal/FunWrappers/TH.hs
+++ b/inline-r/src/Language/R/Internal/FunWrappers/TH.hs
@@ -78,7 +78,13 @@ thWrapperLiteral n = do
     let mkTy []     = impossible "thWrapperLiteral"
         mkTy [x]    = [t| $nR $s $x |]
         mkTy (x:xs) = [t| $x -> $(mkTy xs) |]
-        ctx = cxt (zipWith f (map varT names1) (map varT names2))
+        ctx = cxt $
+#if MIN_VERSION_template_haskell(2,10,0)
+              [AppT (ConT (mkName "NFData")) <$> varT (last names1)] ++
+#else
+              [classP (mkName "NFData") [varT (last names1)]] ++
+#endif
+              zipWith f (map varT names1) (map varT names2)
           where
 #if MIN_VERSION_template_haskell(2,10,0)
             f tv1 tv2 = foldl AppT (ConT (mkName "Literal")) <$> sequence [tv1, tv2]

--- a/inline-r/src/Language/R/QQ.hs
+++ b/inline-r/src/Language/R/QQ.hs
@@ -63,7 +63,7 @@ r = QuasiQuoter
 -- TODO some of the above invariants can be checked statically. Do so.
 rsafe :: QuasiQuoter
 rsafe = QuasiQuoter
-    { quoteExp  = \txt -> [| unsafePerformIO $ unsafeRToIO $ H.automaticSome =<< eval =<< $(expQQ txt) |]
+    { quoteExp  = \txt -> [| unsafePerformIO $ runRegion $ H.automaticSome =<< eval =<< $(expQQ txt) |]
     , quotePat  = unimplemented "quotePat"
     , quoteType = unimplemented "quoteType"
     , quoteDec  = unimplemented "quoteDec"

--- a/inline-r/tests/Test/FunPtr.hs
+++ b/inline-r/tests/Test/FunPtr.hs
@@ -60,7 +60,7 @@ tests = testGroup "funptr"
          replicateM_ 10 performGC
          (\(HaveWeak _ x) -> takeMVar x >>= deRefWeak) hwr
   , testCase "funptr works in quasi-quotes" $
-       (((2::Double) @=?) =<<) $ unsafeRToIO $ do
+       (((2::Double) @=?) =<<) $ runRegion $ do
          let foo = (\x -> return $ x + 1) :: Double -> R s Double
          s <- [r| foo_hs(1) |]
          return $ dynSEXP s

--- a/inline-r/tests/Test/Regions.hs
+++ b/inline-r/tests/Test/Regions.hs
@@ -11,6 +11,8 @@ import           H.Prelude
 import qualified Foreign.R as R
 import           Language.R.QQ
 
+import           Control.Memory.Region
+
 import Test.Tasty hiding (defaultMain)
 import Test.Tasty.HUnit
 import Foreign
@@ -56,6 +58,6 @@ tests = testGroup "regions"
     , testCase "runRegion-no-leaked-thunks" $
         ((8 @=?) =<<) $ do
           z <- runRegion $ fmap dynSEXP [r| 5+3 |]
-          _ <- unsafeRToIO $ [r| gc() |]
+          _ <- unsafeToIO ([r| gc() |] :: R V (R.SomeSEXP V))
           return (z::Int32)
     ]

--- a/inline-r/tests/Test/Regions.hs
+++ b/inline-r/tests/Test/Regions.hs
@@ -11,8 +11,6 @@ import           H.Prelude
 import qualified Foreign.R as R
 import           Language.R.QQ
 
-import           Control.Memory.Region
-
 import Test.Tasty hiding (defaultMain)
 import Test.Tasty.HUnit
 import Foreign
@@ -58,6 +56,6 @@ tests = testGroup "regions"
     , testCase "runRegion-no-leaked-thunks" $
         ((8 @=?) =<<) $ do
           z <- runRegion $ fmap dynSEXP [r| 5+3 |]
-          _ <- unsafeToIO ([r| gc() |] :: R V (R.SomeSEXP V))
+          _ <- runRegion $ [r| gc() |] >> return ()
           return (z::Int32)
     ]

--- a/inline-r/tests/Test/Vector.hs
+++ b/inline-r/tests/Test/Vector.hs
@@ -16,6 +16,7 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeSynonymInstances #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE ViewPatterns #-}
 
 {-# OPTIONS_GHC -fno-warn-orphans #-}
@@ -112,11 +113,11 @@ fromListLength = testCase "fromList should have correct length" $ runRegion $ do
     idVec = id
 
 vectorIsImmutable :: TestTree
-vectorIsImmutable = testCase "fromList should have correct length" $ do
+vectorIsImmutable = testCase "immutable vector, should not be affected by SEXP changes" $ do
     i <- runRegion $ do
            s <- fmap (R.cast (sing :: R.SSEXPTYPE 'R.Real)) [r| c(1.0,2.0,3.0) |]
-           let mutV = VM.fromSEXP s
-           let immV = V.fromSEXP s
+           !mutV <- return $ VM.fromSEXP s
+           !immV <- return $ V.fromSEXP s
            VM.unsafeWrite mutV 0 7
            return $ immV V.! 0
     i @?= 1

--- a/inline-r/tests/bench-hexp.hs
+++ b/inline-r/tests/bench-hexp.hs
@@ -31,7 +31,7 @@ import Data.Singletons (sing)
 import Control.Monad.Primitive
 import Criterion.Main
 import Data.Int
-import Data.Vector.Generic (basicUnsafeIndexM)
+import Data.Vector.SEXP (unsafeIndexM)
 import Foreign.Ptr (Ptr)
 import Foreign.Storable (peek)
 import System.IO.Unsafe (unsafePerformIO)
@@ -65,7 +65,7 @@ benchInteger x = do
 benchHExp :: SEXP s a -> Int32
 benchHExp x =
     case hexp x of
-      Int s -> unsafeInlineIO $ basicUnsafeIndexM s 0
+      Int s -> unsafeInlineIO $ s `unsafeIndexM` 0
       _ -> error "unexpected SEXP"
 
 benchUncheckedInteger :: SEXP s 'R.Int -> IO Int32
@@ -75,4 +75,4 @@ benchCast :: SomeSEXP s -> Int32
 benchCast x =
  let y = R.cast (sing :: R.SSEXPTYPE 'R.Int) x
  in case hexp y of
-      Int s -> unsafeInlineIO $ basicUnsafeIndexM s 0
+      Int s -> unsafeInlineIO $ s `unsafeIndexM` 0

--- a/inline-r/tests/bench-qq.hs
+++ b/inline-r/tests/bench-qq.hs
@@ -16,7 +16,6 @@ import H.Prelude as H
 import Language.R.QQ
 
 import Control.Applicative
-import Control.Memory.Region
 import Criterion.Main
 import Data.Int
 import Language.Haskell.TH.Quote
@@ -34,9 +33,6 @@ hFib n@(H.fromSEXP -> 0 :: Int32) = fmap (flip R.asTypeOf n) [r| 0L |]
 hFib n@(H.fromSEXP -> 1 :: Int32) = fmap (flip R.asTypeOf n) [r| 1L |]
 hFib n = (`R.asTypeOf` n) <$> [r| hFib_hs(n_hs - 1L) + hFib_hs(n_hs - 2L) |]
 
-inVoid :: R V s -> R V s
-inVoid = id
-
 main :: IO ()
 main = do
     H.withEmbeddedR H.defaultConfig $ runRegion $ do
@@ -46,10 +42,10 @@ main = do
                    [ bench "pure Haskell" $
                        nf fib 18
                    , bench "compile-time-qq" $
-                       nfIO $ unsafeToIO $ inVoid $ do
+                       nfIO $ unsafeRunRegion $ do
                          [r| fib <<- function(n) {if (n == 1) return(1); if (n == 2) return(2); return(fib(n-1)+fib(n-2))} |] >> return ()
                          [r| fib(18) |]
                    , bench "compile-time-qq-hybrid" $
-                       nfIO $ unsafeToIO $ inVoid $ hFib =<< mkSEXP (18 :: Int32)
+                       nfIO $ unsafeRunRegion $ hFib =<< mkSEXP (18 :: Int32)
                    ]
                ]

--- a/inline-r/tests/test-qq.hs
+++ b/inline-r/tests/test-qq.hs
@@ -104,12 +104,13 @@ main = H.withEmbeddedR H.defaultConfig $ H.runRegion $ do
 
     -- test Vector literal instance
     v1 <- do
-      x <- SMVector.new 3 :: R s (SMVector.MVector V 'R.Int s Int32)
+      x <- SMVector.new 3 :: R s (SMVector.MVector s 'R.Int Int32)
       SMVector.unsafeWrite x 0 1
       SMVector.unsafeWrite x 1 2
       SMVector.unsafeWrite x 2 3
       return x
-    ("c(7, 2, 3)" @=?) =<< [r| v = v1_hs; v[1] <- 7; v |]
+    let v2 = SMVector.release v1 :: SMVector.MVector V 'R.Int Int32
+    ("c(7, 2, 3)" @=?) =<< [r| v = v2_hs; v[1] <- 7; v |]
     io . assertEqual "" "fromList [1,2,3]" . Prelude.show =<< SVector.unsafeFreeze v1
 
     let utf8string = "abcd çéõßø"

--- a/inline-r/tests/test-shootout.hs
+++ b/inline-r/tests/test-shootout.hs
@@ -6,6 +6,7 @@
 --
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE RankNTypes #-}
 
 module Main where
 
@@ -15,6 +16,7 @@ import H.Prelude as H hiding (show)
 import Language.R.QQ
 
 import Control.Monad (forM)
+import Control.Memory.Region
 import qualified Language.Haskell.TH as TH
 import qualified Language.Haskell.TH.Quote as TH
 import System.IO
@@ -23,6 +25,9 @@ import System.Process
 import Test.Tasty
 import Test.Tasty.HUnit
 import Prelude
+
+inVoid :: R V s -> R V s
+inVoid = id
 
 main :: IO ()
 main = do
@@ -36,5 +41,5 @@ main = do
   where
     cmp script qq = testCase script $ do
       x <- readProcess "R" ["--slave"] =<< readFile script
-      y <- capture_ $ H.unsafeRToIO qq
+      y <- capture_ $ H.unsafeToIO $ inVoid qq
       x @=? y

--- a/inline-r/tests/test-shootout.hs
+++ b/inline-r/tests/test-shootout.hs
@@ -41,5 +41,5 @@ main = do
   where
     cmp script qq = testCase script $ do
       x <- readProcess "R" ["--slave"] =<< readFile script
-      y <- capture_ $ H.unsafeToIO $ inVoid qq
+      y <- capture_ $ H.unsafeRunRegion qq
       x @=? y

--- a/inline-r/tests/tests.hs
+++ b/inline-r/tests/tests.hs
@@ -73,7 +73,7 @@ tests torture = testGroup "Unit tests"
             e <- peek R.globalEnv
             R.withProtected (mkSEXPIO $ \x -> return $ x + 1 :: R s Double) $
               \sf -> R.withProtected (mkSEXPIO (2::Double)) $ \d ->
-                       R.withProtected (R.lang2 sf d) (unsafeToIO . inVoid . eval)
+                       R.withProtected (R.lang2 sf d) (unsafeRunRegion . eval)
                        >>= \(R.SomeSEXP s) ->
                               R.cast (sing :: R.SSEXPTYPE 'R.Real) <$>
                               R.tryEval s (R.release e) p
@@ -104,7 +104,7 @@ tests torture = testGroup "Unit tests"
     -- This test helps compiling quasiquoters concurrently from
     -- multiple modules. This in turns helps testing for race
     -- conditions when initializing R from multiple threads.
-  , testCase "qq/concurrent-initialization" $ unsafeToIO $ inVoid $ [r| 1 |] >> return ()
+  , testCase "qq/concurrent-initialization" $ runRegion $ [r| 1 |] >> return ()
   , testCase "sanity check " $ return ()
   ]
 

--- a/inline-r/tests/tests.hs
+++ b/inline-r/tests/tests.hs
@@ -33,13 +33,17 @@ import Test.Tasty.HUnit
 import Test.Tasty.ExpectedFailure
 
 import Control.Applicative
+import Control.Memory.Region
 import Control.Monad (void)
 import Data.List (delete, find)
 import Data.Singletons (sing)
-import Data.Vector.Generic (basicUnsafeIndexM)
+import Data.Vector.SEXP (indexM)
 import Foreign hiding (void)
 import System.Environment (getArgs, lookupEnv, withArgs)
 import Prelude -- Silence AMP warning
+
+inVoid :: R V z -> R V z
+inVoid = id
 
 tests :: Bool -> TestTree
 tests torture = testGroup "Unit tests"
@@ -69,7 +73,7 @@ tests torture = testGroup "Unit tests"
             e <- peek R.globalEnv
             R.withProtected (mkSEXPIO $ \x -> return $ x + 1 :: R s Double) $
               \sf -> R.withProtected (mkSEXPIO (2::Double)) $ \d ->
-                       R.withProtected (R.lang2 sf d) (unsafeRToIO . eval)
+                       R.withProtected (R.lang2 sf d) (unsafeToIO . inVoid . eval)
                        >>= \(R.SomeSEXP s) ->
                               R.cast (sing :: R.SSEXPTYPE 'R.Real) <$>
                               R.tryEval s (R.release e) p
@@ -90,7 +94,7 @@ tests torture = testGroup "Unit tests"
          y <- R.cast (sing :: R.SSEXPTYPE 'R.Real) . R.SomeSEXP
                      <$> mkSEXP (42::Double)
          case hexp y of
-           Real s -> basicUnsafeIndexM s 0
+           Real s -> s `indexM` 0
   , Test.Constraints.tests
   , Test.FunPtr.tests
   , (if torture then id else ignoreTest) Test.GC.tests
@@ -100,7 +104,7 @@ tests torture = testGroup "Unit tests"
     -- This test helps compiling quasiquoters concurrently from
     -- multiple modules. This in turns helps testing for race
     -- conditions when initializing R from multiple threads.
-  , testCase "qq/concurrent-initialization" $ unsafeRToIO $ [r| 1 |] >> return ()
+  , testCase "qq/concurrent-initialization" $ unsafeToIO $ inVoid $ [r| 1 |] >> return ()
   , testCase "sanity check " $ return ()
   ]
 


### PR DESCRIPTION
This rewrite, performed together with @qnikst, has the following goals:

* align the semantics of slicing with that of the `vector` package.
  Previously, only 0-indexed slices were supported.
* Fix a long standing memory leak: when creating a vector using the
  vector API, as opposed to via an R quasiquote (which is the usual
  case), there previously was no way to register a finalizer, so vectors
  created in this manner would persist throughout the lifetime of the
  program.

The latter difficulty in particular stemmed from reusing the `vector`
package implementation for nearly all functions under the hood, to avoid
bugs, but the flipside was that we had to work within the confines of
the generic interface it provides. With this rewrite, we still build on
top of the `vector` package, because on balance it's better to reuse its
stream fusion framework and we get better DRY this way. But we found
a way to make `vector`'s generic interface work for us, using a trick
based on the `reflection` package to inject finalizers where we need
them.