### PR TITLE
added r-cran-ggplot2 to Dockerfile

### DIFF
--- a/etc/Dockerfile
+++ b/etc/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-add-repository ppa:marutter/rrutter \
          python-pip \
          r-base \
          r-base-dev \
+         r-cran-ggplot2 \
     && rm -rf /var/lib/apt/lists/*
 
 # Pin version for repeatability.


### PR DESCRIPTION
I got the following error when running the example in Ihaskell

> Warning message:
> In library(package, lib.loc = lib.loc, character.only = TRUE, logical.return = TRUE,  :
>   there is no package called ‘ggplot2’

adding the r-cran-ggplot2 package seems to have resolved it.