### PR TITLE
Fix parsing procedure.

### DIFF
--- a/inline-r/src/Language/R/QQ.hs
+++ b/inline-r/src/Language/R/QQ.hs
@@ -89,7 +89,7 @@ parse txt = do
       withCString txt $ \ctxt ->
         R.withProtected (R.mkString ctxt) $ \rtxt ->
           alloca $ \status -> do
-            R.withProtected (R.parseVector rtxt 1 status (R.release nilValue)) $ \exprs -> do
+            R.withProtected (R.parseVector rtxt (-1) status (R.release nilValue)) $ \exprs -> do
               rc <- fromIntegral <$> peek status
               unless (R.PARSE_OK == toEnum rc) $
                 throwIO . RError $ "Parse error in: " ++ txt

--- a/inline-r/tests/test-qq.hs
+++ b/inline-r/tests/test-qq.hs
@@ -111,4 +111,13 @@ main = H.withEmbeddedR H.defaultConfig $ H.runRegion $ do
     let utf8string = "abcd çéõßø"
     io . assertEqual "" utf8string =<< fromSEXP <$> R.cast (sing :: R.SSEXPTYPE 'R.String) <$> [r| utf8string_hs |]
 
+
+    -- Disable gctorture, otherwise test takes too long to execute.
+    _ <- [r| gctorture2(0) |]
+    let x = ([1] :: [Double])
+    ("3" @=?) =<< [r| suppressMessages(require("Matrix"))
+                      v <- x_hs + 1
+                      v <- v + 1
+                      v |]
+
     return ()


### PR DESCRIPTION
Previously we passed parameter that allowed R to parse only single
expression instead of all expressions that were passed to
R_parseVector function.