### PR TITLE
Use just the shell file for Nix.

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,18 +1,27 @@
 {pkgs ? import <nixpkgs> { }, ghc ? pkgs.haskell.compiler.ghc}:
 
-# A shell file to build HaskellR against a version of R with
-# the --enable-strict-barrier configure flag enabled for better memory
-# diagnostics.
-
 with pkgs;
 
 let
-  R = pkgs.R.override { enableStrictBarrier = true; };
+  # Uncomment the line below to build HaskellR against a version of R with
+  # the --enable-strict-barrier configure flag enabled for better memory
+  # diagnostics.
+
+  # R = pkgs.R.override { enableStrictBarrier = true; };
 in
 
 haskell.lib.buildStackProject {
   name = "HaskellR";
   inherit ghc;
-  buildInputs = [ ncurses python34Packages.ipython R zeromq zlib ];
+  buildInputs =
+    [ ncurses
+      python34Packages.ipython
+      python34Packages.jupyter_client
+      python34Packages.notebook
+      R
+      zeromq
+      zlib
+    ];
   LANG = "en_US.UTF-8";
+  LD_LIBRARY_PATH = ["${R}/lib/R/"];
 }

--- a/stack.yaml
+++ b/stack.yaml
@@ -11,15 +11,4 @@ docker:
   repo: tweag/haskellr:latest
 
 nix:
-    enable: false
-    packages:
-    - ncurses
-    - pkgconfig
-    - python34Packages.ipython
-    - python34Packages.jupyter_client
-    - python34Packages.notebook
-    - R
-    - zeromq
-    - zlib
-    ## Right now, using just packages: is OK on Linux, not OSX
-    #shell-file: ./shell.nix
+    shell-file: ./shell.nix


### PR DESCRIPTION
Drop the packages section, which was being duplicated (and did diverge)
between the stack.yaml and shell.nix.