### PR TITLE
Remove python install from travis build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_install:
 install:
   - brew update
   - brew tap homebrew/science
-  - brew install r zeromq python
+  - brew install r zeromq
   - pip install ipython
   - stack setup
   - stack --no-terminal -j2 build --only-snapshot --prefetch --test --bench


### PR DESCRIPTION
Current OSX version used by travis already have python
installed, so reinstallation using brew leads to a false negative
failure. This commit removes installation of python.