### PR TITLE
Implement a way to cancel R operation.

### DIFF
--- a/inline-r/src/Foreign/R.chs
+++ b/inline-r/src/Foreign/R.chs
@@ -128,6 +128,7 @@ module Foreign.R
   , emptyEnv
   , globalEnv
   , signalHandlers
+  , interruptsPending
     -- * Communication with runtime
   , printValue
     -- * Low level info header access

--- a/inline-r/src/Foreign/R/Internal.hsc
+++ b/inline-r/src/Foreign/R/Internal.hsc
@@ -231,6 +231,9 @@ foreign import ccall "&R_GlobalEnv" globalEnv :: Ptr (SEXP G R.Env)
 -- | Signal handler switch
 foreign import ccall "&R_SignalHandlers" signalHandlers :: Ptr CInt
 
+-- | Flag that shows if computation should be interrupted.
+foreign import ccall "&R_interrupts_pending" interruptsPending :: Ptr CInt
+
 ----------------------------------------------------------------------------------
 -- Structure header                                                             --
 ----------------------------------------------------------------------------------

--- a/inline-r/tests/tests.hs
+++ b/inline-r/tests/tests.hs
@@ -31,6 +31,8 @@ import Test.Tasty.HUnit
 import Test.Tasty.ExpectedFailure
 
 import Control.Applicative
+import Control.Concurrent
+import Control.Exception (handle)
 import Control.Memory.Region
 import Control.Monad (void)
 import Data.List (delete, find)
@@ -104,6 +106,10 @@ tests torture = testGroup "Unit tests"
     -- conditions when initializing R from multiple threads.
   , testCase "qq/concurrent-initialization" $ runRegion $ [r| 1 |] >> return ()
   , testCase "sanity check " $ return ()
+  , testCase "cancel works" $ do
+      void $ forkIO $ cancel
+      handle (\RError{} -> return ())
+             (runRegion $ void $ [r| while(1){}; |])
   ]
 
 main :: IO ()


### PR DESCRIPTION
Introduce 'cancel :: IO ()'. This function interrupts R computation
in a safe point.

Fixes #278.