### PR TITLE
Fix Linux and OSX builds.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,6 +43,7 @@ jobs:
       - run:
           name: Build dependencies
           command: |
+            nix-env -f nixpkgs.nix -iA haskell.compiler.ghc883
             nix-shell --run 'stack --no-terminal build --only-snapshot --prefetch --no-haddock --test --bench --jobs=1 --system-ghc'
       - save_cache:
           key: HaskellR-stack-dependencies-2-{{ arch }}-{{ checksum "/tmp/stack-deps" }}
@@ -67,7 +68,7 @@ jobs:
           name: prepare system
           command: |
             mkdir -p ~/.local/bin
-            curl -Lk https://www.stackage.org/stack/osx-x86_64 | tar xz --strip-components=1 -C ~/.local/bin
+            curl -Lk https://get.haskellstack.org/stable/osx-x86_64.tar.gz | tar xz --strip-components=1 -C ~/.local/bin
       - run:
           name: install software
           command: |
@@ -123,7 +124,6 @@ workflows:
   build:
     jobs:
       - build-linux-nix
-      - build-osx-brew
       - build-osx-nix
   publish:
     jobs:

--- a/etc/Dockerfile
+++ b/etc/Dockerfile
@@ -1,4 +1,4 @@
-FROM fpco/stack-build:lts-9.0
+FROM fpco/stack-build:lts-15
 MAINTAINER Mathieu Boespflug <m@tweag.io>
 
 # Install system dependencies.

--- a/inline-r/src/Foreign/R.hsc
+++ b/inline-r/src/Foreign/R.hsc
@@ -156,7 +156,9 @@ module Foreign.R
   ) where
 
 import Control.Memory.Region
+#if __GLASGOW_HASKELL__ < 804
 import Data.Monoid ((<>))
+#endif
 import Foreign.R.Internal
 import Foreign.R.Type
 import Foreign.R.Type as R

--- a/inline-r/src/Foreign/R/Type.hsc
+++ b/inline-r/src/Foreign/R/Type.hsc
@@ -34,7 +34,7 @@
 module Foreign.R.Type
   ( SEXPTYPE(..)
   , SSEXPTYPE(..)
-  , Sing(..)
+  , Sing
   , Logical(..)
   , PairList
   , IsVector

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-15.6
+resolver: lts-15.8
 
 packages:
 - examples


### PR DESCRIPTION
Commit includes the following changes:

* Update docker image (use latest LTS), it was 9.0, quite an old one.
* Use latest OSX stack, previous on was outdated and the URL was linked to nowhere.
* Install ghc-8.8.3 manually bypassing stack on linux setup.

Minor fixes in the library, to allow stack pedantic to pass:
* Fix Foreign.R.Type export
* Fix Data.Monoid import in Foreign.R


* Disable brew build, takes too much time and it's not reproducible.