### PR TITLE
Update to latest LTS and fix CI scripts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,6 +43,7 @@ jobs:
       - run:
           name: Build dependencies
           command: |
+            nix-env -f nixpkgs.nix -iA haskell.compiler.ghc883
             nix-shell --run 'stack --no-terminal build --only-snapshot --prefetch --no-haddock --test --bench --jobs=1 --system-ghc'
       - save_cache:
           key: HaskellR-stack-dependencies-2-{{ arch }}-{{ checksum "/tmp/stack-deps" }}
@@ -67,7 +68,7 @@ jobs:
           name: prepare system
           command: |
             mkdir -p ~/.local/bin
-            curl -Lk https://www.stackage.org/stack/osx-x86_64 | tar xz --strip-components=1 -C ~/.local/bin
+            curl -Lk https://get.haskellstack.org/stable/osx-x86_64.tar.gz | tar xz --strip-components=1 -C ~/.local/bin
       - run:
           name: install software
           command: |
@@ -123,7 +124,6 @@ workflows:
   build:
     jobs:
       - build-linux-nix
-      - build-osx-brew
       - build-osx-nix
   publish:
     jobs:

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 /dist/
+/dist-newstyle/
 .cabal-sandbox
 cabal.sandbox.config
+stack.yaml.lock
 .stack-work
 *.wixobj
 *.msi

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,36 +3,46 @@ version: "{build}"
 build:
   verbosity: normal
 
-environment:
-  global:
-    STACK_ROOT: "c:\\sr"
+clone_folder: "c:\\WORK"
+clone_depth: 5
 
-cache:
-- C:\sr -> stack.yaml                            # The stack root dir.
-- C:\Users\appveyor\AppData\Local\Programs\stack\i386-windows
+# Do not build feature branch with open Pull Requests
+skip_branch_with_pr: true
+
+platform:
+  - x86_64
 
 deploy: off
 
+cache:
+  - "C:\\SR"
+  - dist-newstyle
+
+environment:
+  global:
+    CABOPTS: --store-dir=C:\\SR
+
+  matrix:
+    - GHCVER: 8.8.3
+
+# enable RDP, see https://www.appveyor.com/docs/how-to/rdp-to-build-worker/
+# init:
+#   - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+#
+# on_finish:
+#   - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+
 install:
-  ps: |
-    bash -c 'curl -Lso stack.zip -L --insecure http://www.stackage.org/stack/windows-i386'
-    7z x stack.zip stack.exe
-    mkdir C:\stack
-    mv stack.exe C:\stack
+  - choco source add -n mistuke -s https://www.myget.org/F/mistuke/api/v2
+  - choco install -y cabal --version 3.0.0.0
+  - choco install -y ghc   --version %GHCVER%
+  - choco install -y r
+  - refreshenv
 
-    # The URL keeps changing from release to release and old versions
-    # aren't kept around. In order to prevent the package from
-    # stopping to work, we automatically find the latest version:
-
-    $baseUrl='http://cran.at.r-project.org/bin/windows/base/'
-    $wc = New-Object System.Net.WebClient
-    if(!($wc.DownloadString($baseUrl) -match "R-(\d\.\d\.\d)-win.exe")) {
-      throw "Unable to determine latest version from $baseUrl"
-    }
-    $wc.DownloadFile("$baseUrl$($Matches[0])", "$pwd\Rinstaller.exe")
-    Start-Process -FilePath .\Rinstaller.exe -ArgumentList "/VERYSILENT /DIR=C:\R" -NoNewWindow -Wait
+before_build:
+  - cabal --version
+  - ghc   --version
+  - cabal %CABOPTS% update
 
 build_script:
-  - set PATH=C:\stack;C:\R\bin\i386;%PATH%
-  - stack --no-terminal setup > nul
-  - stack --no-terminal --extra-lib-dirs="C:\R\bin\i386" --extra-include-dirs="C:\R\include" build --test --no-run-tests inline-r H
+  - cabal %CABOPTS% build all --extra-lib-dirs="C:/Program files/R/R-3.6.3/bin/x64" --extra-include-dirs="C:/Program files/R/R-3.6.3/include"

--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,3 @@
+packages:
+  inline-r
+  H

--- a/etc/Dockerfile
+++ b/etc/Dockerfile
@@ -1,4 +1,4 @@
-FROM fpco/stack-build:lts-9.0
+FROM fpco/stack-build:lts-15
 MAINTAINER Mathieu Boespflug <m@tweag.io>
 
 # Install system dependencies.

--- a/inline-r/src/Foreign/R.hsc
+++ b/inline-r/src/Foreign/R.hsc
@@ -156,7 +156,9 @@ module Foreign.R
   ) where
 
 import Control.Memory.Region
+#if __GLASGOW_HASKELL__ < 804
 import Data.Monoid ((<>))
+#endif
 import Foreign.R.Internal
 import Foreign.R.Type
 import Foreign.R.Type as R

--- a/inline-r/src/Foreign/R/Type.hsc
+++ b/inline-r/src/Foreign/R/Type.hsc
@@ -34,7 +34,7 @@
 module Foreign.R.Type
   ( SEXPTYPE(..)
   , SSEXPTYPE(..)
-  , Sing(..)
+  , Sing
   , Logical(..)
   , PairList
   , IsVector

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-15.6
+resolver: lts-15.8
 
 packages:
 - examples


### PR DESCRIPTION
Commit includes the following changes:

Update docker image (use latest LTS), it was 9.0, quite an old one.
Use latest OSX stack, previous on was outdated and the URL was linked to nowhere.
Install ghc-8.8.3 manually bypassing stack on linux setup.
Minor fixes in the library, to allow stack pedantic to pass:

Fix Foreign.R.Type export

Fix Data.Monoid import in Foreign.R

Disable brew build, takes too much time and it's not reproducible.