### PR TITLE
Fix up the build plan for ghcs 8.10 to 9.2

### DIFF
--- a/.github/workflows/cabal.yaml
+++ b/.github/workflows/cabal.yaml
@@ -9,14 +9,20 @@ jobs:
     runs-on:
       - ubuntu-latest
 
+    continue-on-error: ${{ matrix.experimental }}
+
     strategy:
       fail-fast: false
+
       matrix:
+        experimental: [false]
         ghc:
           - '8.10'
           - '9.0'
           - '9.2'
-          - '9.4'
+        include:
+          - ghc: 9.4
+            experimental: true
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/cabal.yaml
+++ b/.github/workflows/cabal.yaml
@@ -1,0 +1,58 @@
+name: Haskell CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on:
+      - ubuntu-latest
+
+    strategy:
+      matrix:
+        ghc:
+          - '8.10'
+          - '9.0'
+          - '9.2'
+          - '9.4'
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup Haskell
+        id: setup-haskell
+        uses: haskell/actions/setup@v2
+        with:
+          ghc-version: ${{ matrix.ghc }}
+          cabal: latest
+
+      - name: Setup caching
+        uses: actions/cache@v3
+        with:
+          path: ${{ steps.setup-haskell.outputs.cabal-store }}
+          key: ${{ runner.os }}-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-
+
+      - name: Install cabal-plan
+        run: |
+          cd $(mktemp -d)
+          cabal install cabal-plan
+
+      - name: Install system dependencies
+        run: apt-get install --no-install-recommends r-base-dev
+
+      - name: Show build plan
+        run: |
+          cabal build all --dry-run
+          cabal-plan
+
+      - name: Build dependencies
+        run: cabal build all --only-dependencies
+
+      - name: Build
+        run: cabal build all
+
+      - name: Test
+        run: cabal test all

--- a/.github/workflows/cabal.yaml
+++ b/.github/workflows/cabal.yaml
@@ -40,6 +40,7 @@ jobs:
         run: |
           cd $(mktemp -d)
           cabal install cabal-plan
+          echo "$HOME/.cabal/bin" >> $GITHUB_PATH
 
       - name: Install system dependencies
         run: sudo apt-get install --no-install-recommends r-base-dev libzmq5-dev

--- a/.github/workflows/cabal.yaml
+++ b/.github/workflows/cabal.yaml
@@ -26,7 +26,7 @@ jobs:
         uses: haskell/actions/setup@v2
         with:
           ghc-version: ${{ matrix.ghc }}
-          cabal: latest
+          cabal-version: latest
 
       - name: Setup caching
         uses: actions/cache@v3
@@ -42,7 +42,7 @@ jobs:
           cabal install cabal-plan
 
       - name: Install system dependencies
-        run: sudo apt-get install --no-install-recommends r-base-dev
+        run: sudo apt-get install --no-install-recommends r-base-dev libzmq5-dev
 
       - name: Show build plan
         run: |

--- a/.github/workflows/cabal.yaml
+++ b/.github/workflows/cabal.yaml
@@ -10,6 +10,7 @@ jobs:
       - ubuntu-latest
 
     strategy:
+      fail-fast: false
       matrix:
         ghc:
           - '8.10'
@@ -41,7 +42,7 @@ jobs:
           cabal install cabal-plan
 
       - name: Install system dependencies
-        run: apt-get install --no-install-recommends r-base-dev
+        run: sudo apt-get install --no-install-recommends r-base-dev
 
       - name: Show build plan
         run: |

--- a/.github/workflows/cabal.yaml
+++ b/.github/workflows/cabal.yaml
@@ -15,14 +15,25 @@ jobs:
       fail-fast: false
 
       matrix:
-        experimental: [false]
-        ghc:
-          - '8.10'
-          - '9.0'
-          - '9.2'
         include:
-          - ghc: 9.4
-            experimental: true
+          - experimental: false
+            project-file: ./cabal.project
+            ghc: 8.10.7
+          - experimental: false
+            project-file: ./cabal.project
+            ghc: 9.0.2
+          - experimental: true
+            project-file: ./cabal.project
+            ghc: 9.4.2
+          - experimental: false
+            project-file: ./cabal.project.lts-18
+            ghc: 8.10.7
+          - experimental: false
+            project-file: ./cabal.project.lts-19
+            ghc: 9.0.2
+          - experimental: false
+            project-file: ./cabal.project.nightly-2022-01-23
+            ghc: 9.0.2
 
     steps:
       - uses: actions/checkout@v2
@@ -53,14 +64,14 @@ jobs:
 
       - name: Show build plan
         run: |
-          cabal build all --dry-run
+          cabal build all --project-file ${{ matrix.project-file }} --dry-run
           cabal-plan
 
       - name: Build dependencies
-        run: cabal build all --only-dependencies
+        run: cabal build all --project-file ${{ matrix.project-file }} --only-dependencies
 
       - name: Build
-        run: cabal build all
+        run: cabal build all --project-file ${{ matrix.project-file }}
 
       - name: Test
-        run: cabal test all
+        run: cabal test all --project-file ${{ matrix.project-file }}

--- a/H/H.cabal
+++ b/H/H.cabal
@@ -35,4 +35,4 @@ executable H
         pretty >=1.1 && <1.2,
         process >=1.2 && <1.7,
         temporary >=1.2.0.3 && <1.4,
-        vector >=0.10 && <0.13
+        vector >=0.10 && <0.14

--- a/H/H.cabal
+++ b/H/H.cabal
@@ -1,35 +1,38 @@
-name:                H
-version:             0.9.0.1
-license:             BSD3
-license-file:        LICENSE
-copyright:           Copyright (c) 2013-2015 Amgen, Inc.
-                     Copyright (c) 2015-2018 Tweag I/O Limited.
-author:              Mathieu Boespflug, Facundo Dominguez, Alexander Vershilov
-maintainer:          Mathieu Boespflug <m@tweag.io>
-build-type:          Simple
-Category:            FFI
-Synopsis:            The Haskell/R mixed programming environment.
-description:         This package is part of the HaskellR project.
-homepage:            https://tweag.github.io/HaskellR
-cabal-version:       >=1.10
-extra-source-files:  H.ghci
+cabal-version:      >=1.10
+name:               H
+version:            0.9.0.1
+license:            BSD3
+license-file:       LICENSE
+copyright:
+    Copyright (c) 2013-2015 Amgen, Inc.
+    Copyright (c) 2015-2018 Tweag I/O Limited.
+
+maintainer:         Mathieu Boespflug <m@tweag.io>
+author:             Mathieu Boespflug, Facundo Dominguez, Alexander Vershilov
+homepage:           https://tweag.github.io/HaskellR
+synopsis:           The Haskell/R mixed programming environment.
+description:        This package is part of the HaskellR project.
+category:           FFI
+build-type:         Simple
+extra-source-files: H.ghci
 
 source-repository head
-  type:     git
-  location: git://github.com/tweag/HaskellR.git
-  subdir: H
+    type:     git
+    location: git://github.com/tweag/HaskellR.git
+    subdir:   H
 
 executable H
-  main-is:             H.hs
-  other-modules:       Paths_H
-  build-depends:       base >= 4.6 && < 5
-                     , bytestring >= 0.10
-                     , cmdargs >= 0.10.5
-                     , file-embed >= 0.0.7
-                     , inline-r >= 0.9 && < 0.11
-                     , pretty >= 1.1
-                     , process >= 1.2
-                     , temporary >= 1.2.0.3
-                     , vector >= 0.10
-  default-language:    Haskell2010
-  ghc-options:         -Wall -threaded
+    main-is:          H.hs
+    other-modules:    Paths_H
+    default-language: Haskell2010
+    ghc-options:      -Wall -threaded
+    build-depends:
+        base >=4.6 && <5,
+        bytestring >=0.10 && <0.11,
+        cmdargs >=0.10.5 && <0.11,
+        file-embed >=0.0.7 && <0.1,
+        inline-r >=0.9 && <0.11,
+        pretty >=1.1 && <1.2,
+        process >=1.2 && <1.7,
+        temporary >=1.2.0.3 && <1.4,
+        vector >=0.10 && <0.13

--- a/H/H.cabal
+++ b/H/H.cabal
@@ -1,38 +1,35 @@
-cabal-version:      >=1.10
-name:               H
-version:            0.9.0.1
-license:            BSD3
-license-file:       LICENSE
-copyright:
-    Copyright (c) 2013-2015 Amgen, Inc.
-    Copyright (c) 2015-2018 Tweag I/O Limited.
-
-maintainer:         Mathieu Boespflug <m@tweag.io>
-author:             Mathieu Boespflug, Facundo Dominguez, Alexander Vershilov
-homepage:           https://tweag.github.io/HaskellR
-synopsis:           The Haskell/R mixed programming environment.
-description:        This package is part of the HaskellR project.
-category:           FFI
-build-type:         Simple
-extra-source-files: H.ghci
+name:                H
+version:             0.9.0.1
+license:             BSD3
+license-file:        LICENSE
+copyright:           Copyright (c) 2013-2015 Amgen, Inc.
+                     Copyright (c) 2015-2018 Tweag I/O Limited.
+author:              Mathieu Boespflug, Facundo Dominguez, Alexander Vershilov
+maintainer:          Mathieu Boespflug <m@tweag.io>
+build-type:          Simple
+Category:            FFI
+Synopsis:            The Haskell/R mixed programming environment.
+description:         This package is part of the HaskellR project.
+homepage:            https://tweag.github.io/HaskellR
+cabal-version:       >=1.10
+extra-source-files:  H.ghci
 
 source-repository head
-    type:     git
-    location: git://github.com/tweag/HaskellR.git
-    subdir:   H
+  type:     git
+  location: git://github.com/tweag/HaskellR.git
+  subdir: H
 
 executable H
-    main-is:          H.hs
-    other-modules:    Paths_H
-    default-language: Haskell2010
-    ghc-options:      -Wall -threaded
-    build-depends:
-        base >=4.6 && <5,
-        bytestring >=0.10 && <0.12,
-        cmdargs >=0.10.5 && <0.11,
-        file-embed >=0.0.7 && <0.1,
-        inline-r >=0.9 && <0.11,
-        pretty >=1.1 && <1.2,
-        process >=1.2 && <1.7,
-        temporary >=1.2.0.3 && <1.4,
-        vector >=0.10 && <0.14
+  main-is:             H.hs
+  other-modules:       Paths_H
+  build-depends:       base >= 4.6 && < 5
+                     , bytestring >= 0.10 && <0.12
+                     , cmdargs >= 0.10.5 && <0.11
+                     , file-embed >= 0.0.7 && <0.1
+                     , inline-r >= 0.9 && <0.11
+                     , pretty >= 1.1 && <1.2
+                     , process >= 1.2 && <1.7
+                     , temporary >= 1.2.0.3 && <1.4
+                     , vector >= 0.10 && <0.14
+  default-language:    Haskell2010
+  ghc-options:         -Wall -threaded

--- a/H/H.cabal
+++ b/H/H.cabal
@@ -28,7 +28,7 @@ executable H
     ghc-options:      -Wall -threaded
     build-depends:
         base >=4.6 && <5,
-        bytestring >=0.10 && <0.11,
+        bytestring >=0.10 && <0.12,
         cmdargs >=0.10.5 && <0.11,
         file-embed >=0.0.7 && <0.1,
         inline-r >=0.9 && <0.11,

--- a/IHaskell/ihaskell-inline-r.cabal
+++ b/IHaskell/ihaskell-inline-r.cabal
@@ -31,7 +31,7 @@ library
         ihaskell-blaze >=0.3.0.1 && <0.4,
         filepath >=1.4.2.1 && <1.5,
         blaze-html >=0.9.1.2 && <0.10,
-        bytestring >=0.10.12.1 && <0.12,
+        bytestring >=0.10.12.0 && <0.12,
         base64-bytestring >=1.2.1.0 && <1.3,
-        template-haskell >=2.17.0.0 && <2.19,
+        template-haskell >=2.16.0.0 && <2.19,
         temporary >=1.2 && <1.4

--- a/IHaskell/ihaskell-inline-r.cabal
+++ b/IHaskell/ihaskell-inline-r.cabal
@@ -31,7 +31,7 @@ library
         ihaskell-blaze >=0.3.0.1 && <0.4,
         filepath >=1.4.2.1 && <1.5,
         blaze-html >=0.9.1.2 && <0.10,
-        bytestring >=0.10.12.1 && <0.11,
+        bytestring >=0.10.12.1 && <0.12,
         base64-bytestring >=1.2.1.0 && <1.3,
-        template-haskell >=2.17.0.0 && <2.18,
+        template-haskell >=2.17.0.0 && <2.19,
         temporary >=1.2 && <1.4

--- a/IHaskell/ihaskell-inline-r.cabal
+++ b/IHaskell/ihaskell-inline-r.cabal
@@ -1,37 +1,37 @@
-cabal-version:      >=1.10
-name:               ihaskell-inline-r
-version:            0.1.1.1
-license:            BSD3
-license-file:       LICENSE
-copyright:          Copyright (c) 2015, Tweag I/O Limited.
-maintainer:         Alexander Vershilov <alexander.vershilov@tweag.io>
-author:             Mathieu Boespflug, Alexander Vershilov
-homepage:           https://tweag.github.io/HaskellR/
-synopsis:           Embed R quasiquotes and plots in IHaskell notebooks.
-description:        Embed R quasiquotes and plots in IHaskell notebooks.
-category:           Development
-build-type:         Simple
-extra-source-files: ChangeLog.markdown
-
-source-repository head
-    type:     git
-    location: https://github.com/tweag/HaskellR.git
-    subdir:   IHaskell
+name:                ihaskell-inline-r
+version:             0.1.1.1
+synopsis:            Embed R quasiquotes and plots in IHaskell notebooks.
+description:         Embed R quasiquotes and plots in IHaskell notebooks.
+homepage:            https://tweag.github.io/HaskellR/
+license:             BSD3
+license-file:        LICENSE
+author:              Mathieu Boespflug, Alexander Vershilov
+maintainer:          Alexander Vershilov <alexander.vershilov@tweag.io>
+copyright:           Copyright (c) 2015, Tweag I/O Limited.
+category:            Development
+build-type:          Simple
+cabal-version:       >=1.10
+extra-source-files:  ChangeLog.markdown
 
 library
-    exposed-modules:  IHaskell.Display.InlineR
-    hs-source-dirs:   src
-    default-language: Haskell2010
-    other-extensions: TemplateHaskell QuasiQuotes
-    ghc-options:      -Wall
-    build-depends:
-        base >=4.7 && <5,
-        inline-r >=0.6.0.1,
-        ihaskell >=0.10.3.0 && <0.11,
-        ihaskell-blaze >=0.3.0.1 && <0.4,
-        filepath >=1.4.2.1 && <1.5,
-        blaze-html >=0.9.1.2 && <0.10,
-        bytestring >=0.10.12.0 && <0.12,
-        base64-bytestring >=1.2.1.0 && <1.3,
-        template-haskell >=2.16.0.0 && <2.19,
-        temporary >=1.2 && <1.4
+  exposed-modules:     IHaskell.Display.InlineR
+  build-depends:       base >=4.7 && <5
+                      ,inline-r >=0.6.0.1 && <1.11
+                      ,ihaskell >=0.10.3.0 && <0.11
+                      ,ihaskell-blaze >=0.3.0.1 && <0.4
+                      ,filepath >=1.4.2.1 && <1.5
+                      ,blaze-html >=0.9.1.2 && <0.10
+                      ,bytestring >=0.10.12.0 && <0.12
+                      ,base64-bytestring >=1.2.1.0 && <1.3
+                      ,template-haskell >=2.16.0.0 && <2.19
+                      ,temporary >=1.2 && <1.4
+  other-extensions:    TemplateHaskell
+                       QuasiQuotes
+  hs-source-dirs:      src
+  default-language:    Haskell2010
+  ghc-options:         -Wall
+
+source-repository head
+  type: git
+  location: https://github.com/tweag/HaskellR.git
+  subdir: IHaskell

--- a/IHaskell/ihaskell-inline-r.cabal
+++ b/IHaskell/ihaskell-inline-r.cabal
@@ -1,37 +1,37 @@
-name:                ihaskell-inline-r
-version:             0.1.1.1
-synopsis:            Embed R quasiquotes and plots in IHaskell notebooks.
-description:         Embed R quasiquotes and plots in IHaskell notebooks.
-homepage:            https://tweag.github.io/HaskellR/
-license:             BSD3
-license-file:        LICENSE
-author:              Mathieu Boespflug, Alexander Vershilov
-maintainer:          Alexander Vershilov <alexander.vershilov@tweag.io>
-copyright:           Copyright (c) 2015, Tweag I/O Limited.
-category:            Development
-build-type:          Simple
-cabal-version:       >=1.10
-extra-source-files:  ChangeLog.markdown
-
-library
-  exposed-modules:     IHaskell.Display.InlineR
-  build-depends:       base >=4.7 && <5
-                      ,inline-r >= 0.6.0.1
-                      ,ihaskell
-                      ,ihaskell-blaze
-                      ,filepath
-                      ,blaze-html
-                      ,bytestring
-                      ,base64-bytestring
-                      ,template-haskell
-                      ,temporary >= 1.2
-  other-extensions:    TemplateHaskell
-                       QuasiQuotes
-  hs-source-dirs:      src
-  default-language:    Haskell2010
-  ghc-options:         -Wall
+cabal-version:      >=1.10
+name:               ihaskell-inline-r
+version:            0.1.1.1
+license:            BSD3
+license-file:       LICENSE
+copyright:          Copyright (c) 2015, Tweag I/O Limited.
+maintainer:         Alexander Vershilov <alexander.vershilov@tweag.io>
+author:             Mathieu Boespflug, Alexander Vershilov
+homepage:           https://tweag.github.io/HaskellR/
+synopsis:           Embed R quasiquotes and plots in IHaskell notebooks.
+description:        Embed R quasiquotes and plots in IHaskell notebooks.
+category:           Development
+build-type:         Simple
+extra-source-files: ChangeLog.markdown
 
 source-repository head
-  type: git
-  location: https://github.com/tweag/HaskellR.git
-  subdir: IHaskell
+    type:     git
+    location: https://github.com/tweag/HaskellR.git
+    subdir:   IHaskell
+
+library
+    exposed-modules:  IHaskell.Display.InlineR
+    hs-source-dirs:   src
+    default-language: Haskell2010
+    other-extensions: TemplateHaskell QuasiQuotes
+    ghc-options:      -Wall
+    build-depends:
+        base >=4.7 && <5,
+        inline-r >=0.6.0.1,
+        ihaskell >=0.10.3.0 && <0.11,
+        ihaskell-blaze >=0.3.0.1 && <0.4,
+        filepath >=1.4.2.1 && <1.5,
+        blaze-html >=0.9.1.2 && <0.10,
+        bytestring >=0.10.12.1 && <0.11,
+        base64-bytestring >=1.2.1.0 && <1.3,
+        template-haskell >=2.17.0.0 && <2.18,
+        temporary >=1.2 && <1.4

--- a/IHaskell/ihaskell-inline-r.cabal
+++ b/IHaskell/ihaskell-inline-r.cabal
@@ -17,12 +17,12 @@ library
   exposed-modules:     IHaskell.Display.InlineR
   build-depends:       base >=4.7 && <5
                       ,inline-r >=0.6.0.1 && <1.11
-                      ,ihaskell >=0.10.3.0 && <0.11
+                      ,ihaskell >=0.10.2.2 && <0.11
                       ,ihaskell-blaze >=0.3.0.1 && <0.4
                       ,filepath >=1.4.2.1 && <1.5
                       ,blaze-html >=0.9.1.2 && <0.10
                       ,bytestring >=0.10.12.0 && <0.12
-                      ,base64-bytestring >=1.2.1.0 && <1.3
+                      ,base64-bytestring >=1.1.0.0 && <1.3
                       ,template-haskell >=2.16.0.0 && <2.19
                       ,temporary >=1.2 && <1.4
   other-extensions:    TemplateHaskell

--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,7 @@
+packages:
+  examples
+  H
+  IHaskell
+  inline-r
+
+test-show-details: direct

--- a/cabal.project
+++ b/cabal.project
@@ -5,3 +5,5 @@ packages:
   inline-r
 
 test-show-details: direct
+
+index-state: 2022-11-06T23:49:06Z

--- a/cabal.project.lts-18
+++ b/cabal.project.lts-18
@@ -1,0 +1,9 @@
+packages:
+  examples
+  H
+  IHaskell
+  inline-r
+
+test-show-details: direct
+
+import: https://www.stackage.org/lts-18.28/cabal.config

--- a/cabal.project.lts-19
+++ b/cabal.project.lts-19
@@ -1,0 +1,9 @@
+packages:
+  examples
+  H
+  IHaskell
+  inline-r
+
+test-show-details: direct
+
+import: https://www.stackage.org/lts-19.31/cabal.config

--- a/cabal.project.nightly-2022-01-23
+++ b/cabal.project.nightly-2022-01-23
@@ -1,0 +1,9 @@
+packages:
+  examples
+  H
+  IHaskell
+  inline-r
+
+test-show-details: direct
+
+import: https://www.stackage.org/nightly-2022-01-23/cabal.config

--- a/examples/HaskellR-examples.cabal
+++ b/examples/HaskellR-examples.cabal
@@ -65,6 +65,6 @@ executable RelaxWithNM
     build-depends:
         inline-r,
         base >=4.6 && <5,
-        deepseq >=1.4.5.0 && <1.5,
+        deepseq >=1.4.4.0 && <1.5,
         integration >=0.2.1 && <0.3,
         temporary >=1.2.0.3 && <1.4

--- a/examples/HaskellR-examples.cabal
+++ b/examples/HaskellR-examples.cabal
@@ -1,63 +1,70 @@
-name:                HaskellR-examples
-version:             0.1.0.0
-license:             AllRightsReserved
-copyright:           Copyright (c) 2013-2015 Amgen, Inc.
-                     Copyright (c) 2015 Tweag I/O Limited.
-build-type:          Simple
-Category:            FFI
-Synopsis:            Examples bundled with the HaskellR project
-description:         This package is part of the HaskellR project.
-cabal-version:       >=1.10
+cabal-version:      >=1.10
+name:               HaskellR-examples
+version:            0.1.0.0
+license:            AllRightsReserved
+copyright:
+    Copyright (c) 2013-2015 Amgen, Inc.
+    Copyright (c) 2015 Tweag I/O Limited.
+
+synopsis:           Examples bundled with the HaskellR project
+description:        This package is part of the HaskellR project.
+category:           FFI
+build-type:         Simple
 extra-source-files:
-  nls/nls.H
-  nls2/nls2.H
+    nls/nls.H
+    nls2/nls2.H
 
 source-repository head
-  type:     git
-  location: git://github.com/tweag/HaskellR.git
-  subdir: examples
+    type:     git
+    location: git://github.com/tweag/HaskellR.git
+    subdir:   examples
 
 executable fft
-  main-is:          Main.hs
-  hs-source-dirs:   fft
-  build-depends:      inline-r
-                    , base >= 4.6 && < 5
-  default-language:    Haskell2010
-  ghc-options:         -Wall -threaded
+    main-is:          Main.hs
+    hs-source-dirs:   fft
+    default-language: Haskell2010
+    ghc-options:      -Wall -threaded
+    build-depends:
+        inline-r,
+        base >=4.6 && <5
 
 executable fib
-  main-is:          Main.hs
-  hs-source-dirs:   fib
-  other-modules:    Fib
-  build-depends:      inline-r
-                    , base >= 4.6 && < 5
-  default-language:    Haskell2010
-  ghc-options:         -Wall -threaded
+    main-is:          Main.hs
+    hs-source-dirs:   fib
+    other-modules:    Fib
+    default-language: Haskell2010
+    ghc-options:      -Wall -threaded
+    build-depends:
+        inline-r,
+        base >=4.6 && <5
 
 executable nls
-  main-is:          Main.hs
-  hs-source-dirs:   nls
-  build-depends:      inline-r
-                    , base >= 4.6 && < 5
-                    , mwc-random >= 0.12
-  default-language:    Haskell2010
-  ghc-options:         -Wall -threaded
+    main-is:          Main.hs
+    hs-source-dirs:   nls
+    default-language: Haskell2010
+    ghc-options:      -Wall -threaded
+    build-depends:
+        inline-r,
+        base >=4.6 && <5,
+        mwc-random >=0.12 && <0.16
 
 executable nls2
-  main-is:          Main.hs
-  hs-source-dirs:   nls2
-  build-depends:      inline-r
-                    , base >= 4.6 && < 5
-                    , mwc-random >= 0.12
-  default-language:    Haskell2010
-  ghc-options:         -Wall -threaded
+    main-is:          Main.hs
+    hs-source-dirs:   nls2
+    default-language: Haskell2010
+    ghc-options:      -Wall -threaded
+    build-depends:
+        inline-r,
+        base >=4.6 && <5,
+        mwc-random >=0.12 && <0.16
 
 executable RelaxWithNM
-  main-is:           RelaxWithNM.hs
-  build-depends:       inline-r
-                     , base >= 4.6 && < 5
-                     , deepseq
-                     , integration
-                     , temporary >= 1.2.0.3
-  default-language:    Haskell2010
-  ghc-options:         -Wall -threaded
+    main-is:          RelaxWithNM.hs
+    default-language: Haskell2010
+    ghc-options:      -Wall -threaded
+    build-depends:
+        inline-r,
+        base >=4.6 && <5,
+        deepseq >=1.4.5.0 && <1.5,
+        integration >=0.2.1 && <0.3,
+        temporary >=1.2.0.3 && <1.4

--- a/examples/HaskellR-examples.cabal
+++ b/examples/HaskellR-examples.cabal
@@ -1,70 +1,63 @@
-cabal-version:      >=1.10
-name:               HaskellR-examples
-version:            0.1.0.0
-license:            AllRightsReserved
-copyright:
-    Copyright (c) 2013-2015 Amgen, Inc.
-    Copyright (c) 2015 Tweag I/O Limited.
-
-synopsis:           Examples bundled with the HaskellR project
-description:        This package is part of the HaskellR project.
-category:           FFI
-build-type:         Simple
+name:                HaskellR-examples
+version:             0.1.0.0
+license:             AllRightsReserved
+copyright:           Copyright (c) 2013-2015 Amgen, Inc.
+                     Copyright (c) 2015 Tweag I/O Limited.
+build-type:          Simple
+Category:            FFI
+Synopsis:            Examples bundled with the HaskellR project
+description:         This package is part of the HaskellR project.
+cabal-version:       >=1.10
 extra-source-files:
-    nls/nls.H
-    nls2/nls2.H
+  nls/nls.H
+  nls2/nls2.H
 
 source-repository head
-    type:     git
-    location: git://github.com/tweag/HaskellR.git
-    subdir:   examples
+  type:     git
+  location: git://github.com/tweag/HaskellR.git
+  subdir: examples
 
 executable fft
-    main-is:          Main.hs
-    hs-source-dirs:   fft
-    default-language: Haskell2010
-    ghc-options:      -Wall -threaded
-    build-depends:
-        inline-r,
-        base >=4.6 && <5
+  main-is:          Main.hs
+  hs-source-dirs:   fft
+  build-depends:      inline-r
+                    , base >= 4.6 && < 5
+  default-language:    Haskell2010
+  ghc-options:         -Wall -threaded
 
 executable fib
-    main-is:          Main.hs
-    hs-source-dirs:   fib
-    other-modules:    Fib
-    default-language: Haskell2010
-    ghc-options:      -Wall -threaded
-    build-depends:
-        inline-r,
-        base >=4.6 && <5
+  main-is:          Main.hs
+  hs-source-dirs:   fib
+  other-modules:    Fib
+  build-depends:      inline-r
+                    , base >= 4.6 && < 5
+  default-language:    Haskell2010
+  ghc-options:         -Wall -threaded
 
 executable nls
-    main-is:          Main.hs
-    hs-source-dirs:   nls
-    default-language: Haskell2010
-    ghc-options:      -Wall -threaded
-    build-depends:
-        inline-r,
-        base >=4.6 && <5,
-        mwc-random >=0.12 && <0.16
+  main-is:          Main.hs
+  hs-source-dirs:   nls
+  build-depends:      inline-r
+                    , base >= 4.6 && < 5
+                    , mwc-random >= 0.12 && <0.16
+  default-language:    Haskell2010
+  ghc-options:         -Wall -threaded
 
 executable nls2
-    main-is:          Main.hs
-    hs-source-dirs:   nls2
-    default-language: Haskell2010
-    ghc-options:      -Wall -threaded
-    build-depends:
-        inline-r,
-        base >=4.6 && <5,
-        mwc-random >=0.12 && <0.16
+  main-is:          Main.hs
+  hs-source-dirs:   nls2
+  build-depends:      inline-r
+                    , base >= 4.6 && < 5
+                    , mwc-random >= 0.12 && <0.16
+  default-language:    Haskell2010
+  ghc-options:         -Wall -threaded
 
 executable RelaxWithNM
-    main-is:          RelaxWithNM.hs
-    default-language: Haskell2010
-    ghc-options:      -Wall -threaded
-    build-depends:
-        inline-r,
-        base >=4.6 && <5,
-        deepseq >=1.4.4.0 && <1.5,
-        integration >=0.2.1 && <0.3,
-        temporary >=1.2.0.3 && <1.4
+  main-is:           RelaxWithNM.hs
+  build-depends:       inline-r
+                     , base >= 4.6 && < 5
+                     , deepseq >=1.4.4.0 && <1.5
+                     , integration >=0.2.1 && <0.3
+                     , temporary >= 1.2.0.3 && <1.4
+  default-language:    Haskell2010
+  ghc-options:         -Wall -threaded

--- a/inline-r/inline-r.cabal
+++ b/inline-r/inline-r.cabal
@@ -238,4 +238,4 @@ benchmark bench-hexp
         criterion >=0.8 && <1.7,
         primitive >=0.5 && <0.8,
         vector >=0.10 && <0.13,
-        singletons >=3.0.1 && <3.1
+        singletons >=2.7 && <3.1

--- a/inline-r/inline-r.cabal
+++ b/inline-r/inline-r.cabal
@@ -91,12 +91,13 @@ library
     build-depends:
         base >=4.7 && <5,
         aeson >=0.6 && <2.2,
-        bytestring >=0.10 && <0.11 || >=0.11.3.1 && <0.12,
+        bytestring >=0.10 && <0.12,
         containers >=0.5 && <0.7,
         data-default-class >=0.1.2.0 && <0.2,
         deepseq >=1.3 && <1.5,
         exceptions >=0.6 && <1.1,
         heredoc >=0.2 && <0.3,
+        inline-c >=0.6 && <0.10,
         mtl >=2.1 && <2.3,
         pretty >=1.1 && <1.2,
         primitive >=0.5 && <0.8,
@@ -115,12 +116,6 @@ library
         exposed-modules:
             Foreign.R.EventLoop
             Language.R.Event
-
-    if impl(ghc <8.2.1)
-        build-depends: inline-c >=0.5.6.1 && <0.6 || >=0.9.1.6 && <0.10
-
-    else
-        build-depends: inline-c >=0.6 && <0.10
 
     if impl(ghc <9)
         build-depends: singletons >=2.7 && <3
@@ -171,7 +166,7 @@ test-suite tests
         tasty-hunit >=0.4.1 && <0.11,
         tasty-quickcheck >=0.4.1 && <0.11,
         temporary >=1.2 && <1.4,
-        text >=0.11 && <1.3 || >=2.0.1 && <2.1,
+        text >=0.11 && <2.1,
         vector >=0.12.3.1 && <0.13
 
     if !os(windows)

--- a/inline-r/inline-r.cabal
+++ b/inline-r/inline-r.cabal
@@ -103,9 +103,9 @@ library
         process >=1.2 && <1.7,
         reflection >=2 && <2.2,
         setenv >=0.1.1 && <0.2,
-        template-haskell >=2.8 && <2.18 || >=2.18.0.0 && <2.19,
+        template-haskell >=2.8 && <2.20,
         temporary >=1.2 && <1.4,
-        text >=0.11 && <1.3,
+        text >=0.11 && <2.1,
         th-lift >=0.6 && <0.9,
         th-orphans >=0.8 && <0.14,
         transformers >=0.3 && <0.6,
@@ -171,7 +171,7 @@ test-suite tests
         tasty-hunit >=0.4.1 && <0.11,
         tasty-quickcheck >=0.4.1 && <0.11,
         temporary >=1.2 && <1.4,
-        text >=0.11 && <1.3,
+        text >=0.11 && <1.3 || >=2.0.1 && <2.1,
         vector >=0.12.3.1 && <0.13
 
     if !os(windows)
@@ -190,7 +190,7 @@ test-suite test-qq
         process >=1.2 && <1.7,
         tasty-hunit >=0.4.1 && <0.11,
         singletons >=0.9 && <3.1,
-        text >=0.11 && <1.3
+        text >=0.11 && <2.1
 
 test-suite test-shootout
     type:             exitcode-stdio-1.0
@@ -207,7 +207,7 @@ test-suite test-shootout
         silently >=1.2 && <1.3,
         tasty >=0.3 && <1.5,
         tasty-hunit >=0.4.1 && <0.11,
-        template-haskell >=2.8 && <2.19
+        template-haskell >=2.8 && <2.20
 
     if os(windows)
         buildable: False
@@ -224,7 +224,7 @@ benchmark bench-qq
         criterion >=0.8 && <1.7,
         filepath >=1.3 && <1.5,
         process >=1.2 && <1.7,
-        template-haskell >=2.8 && <2.19
+        template-haskell >=2.8 && <2.20
 
 benchmark bench-hexp
     type:             exitcode-stdio-1.0

--- a/inline-r/inline-r.cabal
+++ b/inline-r/inline-r.cabal
@@ -1,216 +1,240 @@
-name:                inline-r
-version:             0.10.5
-license:             BSD3
-license-file:        LICENSE
-copyright:           Copyright (c) 2013-2015 Amgen, Inc.
-                     Copyright (c) 2015-2020 Tweag I/O Limited.
-author:              Mathieu Boespflug, Facundo Dominguez, Alexander Vershilov
-maintainer:          Mathieu Boespflug <m@tweag.io>
-build-type:          Simple
-Category:            FFI
-Synopsis:            Seamlessly call R from Haskell and vice versa. No FFI required.
+cabal-version:      >=1.10
+name:               inline-r
+version:            0.10.5
+license:            BSD3
+license-file:       LICENSE
+copyright:
+    Copyright (c) 2013-2015 Amgen, Inc.
+    Copyright (c) 2015-2020 Tweag I/O Limited.
+
+maintainer:         Mathieu Boespflug <m@tweag.io>
+author:             Mathieu Boespflug, Facundo Dominguez, Alexander Vershilov
+homepage:           https://tweag.github.io/HaskellR
+synopsis:
+    Seamlessly call R from Haskell and vice versa. No FFI required.
+
 description:
+    For up to date Haddock documentation, please see
+    <http://www.stackage.org/package/inline-r>.
 
-  For up to date Haddock documentation, please see
-  <http://www.stackage.org/package/inline-r>.
+category:           FFI
+build-type:         Simple
+extra-source-files:
+    CHANGELOG.md
+    cbits/missing_r.h
+    tests/shootout/binarytrees.R
+    tests/shootout/fasta.R
+    tests/shootout/knucleotide.R
+    tests/shootout/fastaredux.R
+    tests/shootout/mandelbrot.R
+    tests/shootout/mandelbrot-noout.R
+    tests/shootout/nbody.R
+    tests/shootout/pidigits.R
+    tests/shootout/regexdna.R
+    tests/shootout/reversecomplement.R
+    tests/shootout/spectralnorm.R
+    tests/shootout/spectralnorm-math.R
+    tests/shootout/fannkuchredux.R
+    tests/R/fib.R
+    tests/R/fib-benchmark.R
 
-homepage:            https://tweag.github.io/HaskellR
-cabal-version:       >=1.10
-
-extra-source-files:   CHANGELOG.md
-                      cbits/missing_r.h
-                      tests/shootout/binarytrees.R
-                      tests/shootout/fasta.R
-                      tests/shootout/knucleotide.R
-                      tests/shootout/fastaredux.R
-                      tests/shootout/mandelbrot.R
-                      tests/shootout/mandelbrot-noout.R
-                      tests/shootout/nbody.R
-                      tests/shootout/pidigits.R
-                      tests/shootout/regexdna.R
-                      tests/shootout/reversecomplement.R
-                      tests/shootout/spectralnorm.R
-                      tests/shootout/spectralnorm-math.R
-                      tests/shootout/fannkuchredux.R
-                      tests/R/fib.R
-                      tests/R/fib-benchmark.R
-extra-tmp-files:     inline-r.buildinfo
+extra-tmp-files:    inline-r.buildinfo
 
 source-repository head
-  type:     git
-  location: git://github.com/tweag/HaskellR.git
-  subdir: inline-r
+    type:     git
+    location: git://github.com/tweag/HaskellR.git
+    subdir:   inline-r
 
 library
-  exposed-modules:     Control.Memory.Region
-                       Data.Vector.SEXP
-                       Data.Vector.SEXP.Base
-                       Data.Vector.SEXP.Mutable
-                       Foreign.R
-                       Foreign.R.Constraints
-                       Foreign.R.Context
-                       Foreign.R.Embedded
-                       Foreign.R.Error
-                       Foreign.R.Internal
-                       Foreign.R.Parse
-                       Foreign.R.Type
-                       H.Prelude
-                       H.Prelude.Interactive
-                       Language.R
-                       Language.R.Debug
-                       Language.R.GC
-                       Language.R.Globals
-                       Language.R.HExp
-                       Language.R.Instance
-                       Language.R.Internal
-                       Language.R.Internal.FunWrappers
-                       Language.R.Internal.FunWrappers.TH
-                       Language.R.Literal
-                       Language.R.Matcher
-                       Language.R.QQ
-  if !os(windows)
-    exposed-modules:   Foreign.R.EventLoop
-                       Language.R.Event
-  other-modules:       Control.Monad.R.Class
-                       Control.Monad.R.Internal
-                       Data.Vector.SEXP.Mutable.Internal
-                       Internal.Error
-  build-depends:       base >= 4.7 && < 5
-                     , aeson >= 0.6
-                     , bytestring >= 0.10
-                     , containers >= 0.5
-                     , data-default-class
-                     , deepseq >= 1.3
-                     , exceptions >= 0.6 && < 1.1
-                     , heredoc >= 0.2
-                     , mtl >= 2.1
-                     , pretty >= 1.1
-                     , primitive >= 0.5
-                     , process >= 1.2
-                     , reflection >= 2
-                     , setenv >= 0.1.1
-                     , singletons >= 3
-                     , singletons-th >= 3
-                     , template-haskell >= 2.8
-                     , temporary >= 1.2
-                     , text >= 0.11
-                     , th-lift >= 0.6
-                     , th-orphans >= 0.8
-                     , transformers >= 0.3
-                     , vector >= 0.10 && < 0.13
-  if impl(ghc < 8.2.1)
+    exposed-modules:
+        Control.Memory.Region
+        Data.Vector.SEXP
+        Data.Vector.SEXP.Base
+        Data.Vector.SEXP.Mutable
+        Foreign.R
+        Foreign.R.Constraints
+        Foreign.R.Context
+        Foreign.R.Embedded
+        Foreign.R.Error
+        Foreign.R.Internal
+        Foreign.R.Parse
+        Foreign.R.Type
+        H.Prelude
+        H.Prelude.Interactive
+        Language.R
+        Language.R.Debug
+        Language.R.GC
+        Language.R.Globals
+        Language.R.HExp
+        Language.R.Instance
+        Language.R.Internal
+        Language.R.Internal.FunWrappers
+        Language.R.Internal.FunWrappers.TH
+        Language.R.Literal
+        Language.R.Matcher
+        Language.R.QQ
+
+    build-tools:      hsc2hs >=0
+    c-sources:        cbits/missing_r.c
+    hs-source-dirs:   src
+    other-modules:
+        Control.Monad.R.Class
+        Control.Monad.R.Internal
+        Data.Vector.SEXP.Mutable.Internal
+        Internal.Error
+
+    default-language: Haskell2010
+    other-extensions: CPP ForeignFunctionInterface
+    include-dirs:     cbits
+    includes:         cbits/missing_r.h
+    ghc-options:      -Wall -freduction-depth=32
     build-depends:
-      inline-c >=0.5.6.1 && <0.6
-  else
-    build-depends:
-      inline-c >=0.6
-  hs-source-dirs:      src
-  includes:            cbits/missing_r.h
-  c-sources:           cbits/missing_r.c
-  include-dirs:        cbits
-  default-language:    Haskell2010
-  other-extensions:    CPP
-                       ForeignFunctionInterface
-  build-tools:         hsc2hs
-  if os(windows)
-    extra-libraries:   R
-  else
-    build-depends:     unix >= 2.6
-    pkgconfig-depends: libR >= 3.0
-  -- XXX -fcontext-stack=32 required on GHC >= 7.8 to allow foreign
-  -- export function -wrappers of high arities.
-  ghc-options:         -Wall -freduction-depth=32
+        base >=4.7 && <5,
+        aeson >=0.6 && <2.2,
+        bytestring >=0.10 && <0.11,
+        containers >=0.5 && <0.7,
+        data-default-class >=0.1.2.0 && <0.2,
+        deepseq >=1.3 && <1.5,
+        exceptions >=0.6 && <1.1,
+        heredoc >=0.2 && <0.3,
+        mtl >=2.1 && <2.3,
+        pretty >=1.1 && <1.2,
+        primitive >=0.5 && <0.8,
+        process >=1.2 && <1.7,
+        reflection >=2 && <2.2,
+        setenv >=0.1.1 && <0.2,
+        template-haskell >=2.8 && <2.18,
+        temporary >=1.2 && <1.4,
+        text >=0.11 && <1.3,
+        th-lift >=0.6 && <0.9,
+        th-orphans >=0.8 && <0.14,
+        transformers >=0.3 && <0.6,
+        vector >=0.10 && <0.13
+
+    if !os(windows)
+        exposed-modules:
+            Foreign.R.EventLoop
+            Language.R.Event
+
+    if impl(ghc <8.2.1)
+        build-depends: inline-c >=0.5.6.1 && <0.6 || >=0.9.1.6 && <0.10
+
+    else
+        build-depends: inline-c >=0.6 && <0.10
+
+    if impl(ghc < 9)
+        build-depends: singletons >= 2.7 && <3
+    else
+        build-depends:
+            singletons >=3,
+            singletons-th >=3
+
+    if os(windows)
+        extra-libraries: R
+
+    else
+        pkgconfig-depends: libR >=3.0
+        build-depends:     unix >=2.6 && <2.8
 
 test-suite tests
-  main-is:             tests.hs
-  type:                exitcode-stdio-1.0
-  build-depends:       inline-r
-                     , base >= 4.6 && < 5
-                     , bytestring >= 0.10
-                     , directory >= 1.2
-                     , filepath >= 1.3
-                     , heredoc >= 0.2
-                     , ieee754 >= 0.7
-                     , mtl >= 2.0
-                     , process >= 1.2
-                     , quickcheck-assertions >= 0.1.1
-                     , singletons >= 0.10
-                     , strict >= 0.3.2
-                     , tasty >= 0.11
-                     , tasty-expected-failure >= 0.11
-                     , tasty-golden >= 2.3
-                     , tasty-hunit >= 0.4.1
-                     , tasty-quickcheck >= 0.4.1
-                     , temporary >= 1.2
-                     , text >= 0.11
-                     , vector
-  if !os(windows)
-    build-depends:     unix >= 2.5
-  other-modules:       Test.GC
-                       Test.FunPtr
-                       Test.Constraints
-                       Test.Event
-                       Test.Regions
-                       Test.Vector
-                       Test.Matcher
-  ghc-options:         -Wall -threaded
-  hs-source-dirs:      tests
-  default-language:    Haskell2010
+    type:             exitcode-stdio-1.0
+    main-is:          tests.hs
+    hs-source-dirs:   tests
+    other-modules:
+        Test.GC
+        Test.FunPtr
+        Test.Constraints
+        Test.Event
+        Test.Regions
+        Test.Vector
+        Test.Matcher
+
+    default-language: Haskell2010
+    ghc-options:      -Wall -threaded
+    build-depends:
+        inline-r,
+        base >=4.6 && <5,
+        bytestring >=0.10 && <0.11,
+        directory >=1.2 && <1.4,
+        filepath >=1.3 && <1.5,
+        heredoc >=0.2 && <0.3,
+        ieee754 >=0.7 && <0.9,
+        mtl >=2.0 && <2.3,
+        process >=1.2 && <1.7,
+        quickcheck-assertions >=0.1.1 && <0.4,
+        singletons >=0.10 && <3.1,
+        strict >=0.3.2 && <0.5,
+        tasty >=0.11 && <1.5,
+        tasty-expected-failure >=0.11 && <0.13,
+        tasty-golden >=2.3 && <2.4,
+        tasty-hunit >=0.4.1 && <0.11,
+        tasty-quickcheck >=0.4.1 && <0.11,
+        temporary >=1.2 && <1.4,
+        text >=0.11 && <1.3,
+        vector >=0.12.3.1 && <0.13
+
+    if !os(windows)
+        build-depends: unix >=2.5 && <2.8
 
 test-suite test-qq
-  main-is:             test-qq.hs
-  type:                exitcode-stdio-1.0
-  build-depends:       inline-r
-                     , base >= 4.6 && < 5
-                     , mtl >= 2.0
-                     , process >= 1.2
-                     , tasty-hunit >= 0.4.1
-                     , singletons >= 0.9
-                     , text >= 0.11
-  ghc-options:         -Wall -threaded
-  hs-source-dirs:      tests
-  default-language:    Haskell2010
+    type:             exitcode-stdio-1.0
+    main-is:          test-qq.hs
+    hs-source-dirs:   tests
+    default-language: Haskell2010
+    ghc-options:      -Wall -threaded
+    build-depends:
+        inline-r,
+        base >=4.6 && <5,
+        mtl >=2.0 && <2.3,
+        process >=1.2 && <1.7,
+        tasty-hunit >=0.4.1 && <0.11,
+        singletons >=0.9 && <3.1,
+        text >=0.11 && <1.3
 
 test-suite test-shootout
-  main-is:             test-shootout.hs
-  type:                exitcode-stdio-1.0
-  other-modules:       Test.Scripts
-  build-depends:       inline-r
-                     , base >= 4.6 && < 5
-                     , filepath >= 1.3
-                     , process >= 1.2
-                     , silently >= 1.2
-                     , tasty >= 0.3
-                     , tasty-hunit >= 0.4.1
-                     , template-haskell >= 2.8
-  ghc-options:         -Wall -threaded
-  hs-source-dirs:      tests
-  default-language:    Haskell2010
-  if os(windows)
-    buildable:         False
+    type:             exitcode-stdio-1.0
+    main-is:          test-shootout.hs
+    hs-source-dirs:   tests
+    other-modules:    Test.Scripts
+    default-language: Haskell2010
+    ghc-options:      -Wall -threaded
+    build-depends:
+        inline-r,
+        base >=4.6 && <5,
+        filepath >=1.3 && <1.5,
+        process >=1.2 && <1.7,
+        silently >=1.2 && <1.3,
+        tasty >=0.3 && <1.5,
+        tasty-hunit >=0.4.1 && <0.11,
+        template-haskell >=2.8 && <2.18
+
+    if os(windows)
+        buildable: False
 
 benchmark bench-qq
-  main-is:             bench-qq.hs
-  type:                exitcode-stdio-1.0
-  build-depends:       inline-r
-                     , base >= 4.6 && < 5
-                     , criterion >= 0.8
-                     , filepath >= 1.3
-                     , process >= 1.2
-                     , template-haskell >= 2.8
-  ghc-options:         -Wall -threaded
-  hs-source-dirs:      tests
-  default-language:    Haskell2010
+    type:             exitcode-stdio-1.0
+    main-is:          bench-qq.hs
+    hs-source-dirs:   tests
+    default-language: Haskell2010
+    ghc-options:      -Wall -threaded
+    build-depends:
+        inline-r,
+        base >=4.6 && <5,
+        criterion >=0.8 && <1.7,
+        filepath >=1.3 && <1.5,
+        process >=1.2 && <1.7,
+        template-haskell >=2.8 && <2.18
 
 benchmark bench-hexp
-  main-is:             bench-hexp.hs
-  type:                exitcode-stdio-1.0
-  build-depends:       inline-r
-                     , base >= 4.6 && < 5
-                     , criterion >= 0.8
-                     , primitive >= 0.5
-                     , vector >= 0.10
-                     , singletons
-  ghc-options:         -Wall -threaded
-  hs-source-dirs:      tests
-  default-language:    Haskell2010
+    type:             exitcode-stdio-1.0
+    main-is:          bench-hexp.hs
+    hs-source-dirs:   tests
+    default-language: Haskell2010
+    ghc-options:      -Wall -threaded
+    build-depends:
+        inline-r,
+        base >=4.6 && <5,
+        criterion >=0.8 && <1.7,
+        primitive >=0.5 && <0.8,
+        vector >=0.10 && <0.13,
+        singletons >=3.0.2 && <3.1

--- a/inline-r/inline-r.cabal
+++ b/inline-r/inline-r.cabal
@@ -91,7 +91,7 @@ library
     build-depends:
         base >=4.7 && <5,
         aeson >=0.6 && <2.2,
-        bytestring >=0.10 && <0.11,
+        bytestring >=0.10 && <0.11 || >=0.11.3.1 && <0.12,
         containers >=0.5 && <0.7,
         data-default-class >=0.1.2.0 && <0.2,
         deepseq >=1.3 && <1.5,
@@ -103,7 +103,7 @@ library
         process >=1.2 && <1.7,
         reflection >=2 && <2.2,
         setenv >=0.1.1 && <0.2,
-        template-haskell >=2.8 && <2.18,
+        template-haskell >=2.8 && <2.18 || >=2.18.0.0 && <2.19,
         temporary >=1.2 && <1.4,
         text >=0.11 && <1.3,
         th-lift >=0.6 && <0.9,
@@ -122,12 +122,13 @@ library
     else
         build-depends: inline-c >=0.6 && <0.10
 
-    if impl(ghc < 9)
-        build-depends: singletons >= 2.7 && <3
+    if impl(ghc <9)
+        build-depends: singletons >=2.7 && <3
+
     else
         build-depends:
-            singletons >=3,
-            singletons-th >=3
+            singletons >=3 && <3.1,
+            singletons-th >=3 && <3.2
 
     if os(windows)
         extra-libraries: R
@@ -154,7 +155,7 @@ test-suite tests
     build-depends:
         inline-r,
         base >=4.6 && <5,
-        bytestring >=0.10 && <0.11,
+        bytestring >=0.10 && <0.12,
         directory >=1.2 && <1.4,
         filepath >=1.3 && <1.5,
         heredoc >=0.2 && <0.3,
@@ -206,7 +207,7 @@ test-suite test-shootout
         silently >=1.2 && <1.3,
         tasty >=0.3 && <1.5,
         tasty-hunit >=0.4.1 && <0.11,
-        template-haskell >=2.8 && <2.18
+        template-haskell >=2.8 && <2.19
 
     if os(windows)
         buildable: False
@@ -223,7 +224,7 @@ benchmark bench-qq
         criterion >=0.8 && <1.7,
         filepath >=1.3 && <1.5,
         process >=1.2 && <1.7,
-        template-haskell >=2.8 && <2.18
+        template-haskell >=2.8 && <2.19
 
 benchmark bench-hexp
     type:             exitcode-stdio-1.0
@@ -237,4 +238,4 @@ benchmark bench-hexp
         criterion >=0.8 && <1.7,
         primitive >=0.5 && <0.8,
         vector >=0.10 && <0.13,
-        singletons >=3.0.2 && <3.1
+        singletons >=3.0.1 && <3.1

--- a/inline-r/inline-r.cabal
+++ b/inline-r/inline-r.cabal
@@ -110,7 +110,7 @@ library
         th-lift >=0.6 && <0.9,
         th-orphans >=0.8 && <0.14,
         transformers >=0.3 && <0.6,
-        vector >=0.10 && <0.13
+        vector >=0.10 && <0.14
 
     if !os(windows)
         exposed-modules:
@@ -167,7 +167,7 @@ test-suite tests
         tasty-quickcheck >=0.4.1 && <0.11,
         temporary >=1.2 && <1.4,
         text >=0.11 && <2.1,
-        vector >=0.12.3.1 && <0.13
+        vector >=0.12.3.1 && <0.14
 
     if !os(windows)
         build-depends: unix >=2.5 && <2.8
@@ -232,5 +232,5 @@ benchmark bench-hexp
         base >=4.6 && <5,
         criterion >=0.8 && <1.7,
         primitive >=0.5 && <0.8,
-        vector >=0.10 && <0.13,
+        vector >=0.10 && <0.14,
         singletons >=2.7 && <3.1

--- a/inline-r/inline-r.cabal
+++ b/inline-r/inline-r.cabal
@@ -1,236 +1,221 @@
-cabal-version:      >=1.10
-name:               inline-r
-version:            0.10.5
-license:            BSD3
-license-file:       LICENSE
-copyright:
-    Copyright (c) 2013-2015 Amgen, Inc.
-    Copyright (c) 2015-2020 Tweag I/O Limited.
-
-maintainer:         Mathieu Boespflug <m@tweag.io>
-author:             Mathieu Boespflug, Facundo Dominguez, Alexander Vershilov
-homepage:           https://tweag.github.io/HaskellR
-synopsis:
-    Seamlessly call R from Haskell and vice versa. No FFI required.
-
+name:                inline-r
+version:             0.10.5
+license:             BSD3
+license-file:        LICENSE
+copyright:           Copyright (c) 2013-2015 Amgen, Inc.
+                     Copyright (c) 2015-2020 Tweag I/O Limited.
+author:              Mathieu Boespflug, Facundo Dominguez, Alexander Vershilov
+maintainer:          Mathieu Boespflug <m@tweag.io>
+build-type:          Simple
+Category:            FFI
+Synopsis:            Seamlessly call R from Haskell and vice versa. No FFI required.
 description:
-    For up to date Haddock documentation, please see
-    <http://www.stackage.org/package/inline-r>.
 
-category:           FFI
-build-type:         Simple
-extra-source-files:
-    CHANGELOG.md
-    cbits/missing_r.h
-    tests/shootout/binarytrees.R
-    tests/shootout/fasta.R
-    tests/shootout/knucleotide.R
-    tests/shootout/fastaredux.R
-    tests/shootout/mandelbrot.R
-    tests/shootout/mandelbrot-noout.R
-    tests/shootout/nbody.R
-    tests/shootout/pidigits.R
-    tests/shootout/regexdna.R
-    tests/shootout/reversecomplement.R
-    tests/shootout/spectralnorm.R
-    tests/shootout/spectralnorm-math.R
-    tests/shootout/fannkuchredux.R
-    tests/R/fib.R
-    tests/R/fib-benchmark.R
+  For up to date Haddock documentation, please see
+  <http://www.stackage.org/package/inline-r>.
 
-extra-tmp-files:    inline-r.buildinfo
+homepage:            https://tweag.github.io/HaskellR
+cabal-version:       >=1.10
+
+extra-source-files:   CHANGELOG.md
+                      cbits/missing_r.h
+                      tests/shootout/binarytrees.R
+                      tests/shootout/fasta.R
+                      tests/shootout/knucleotide.R
+                      tests/shootout/fastaredux.R
+                      tests/shootout/mandelbrot.R
+                      tests/shootout/mandelbrot-noout.R
+                      tests/shootout/nbody.R
+                      tests/shootout/pidigits.R
+                      tests/shootout/regexdna.R
+                      tests/shootout/reversecomplement.R
+                      tests/shootout/spectralnorm.R
+                      tests/shootout/spectralnorm-math.R
+                      tests/shootout/fannkuchredux.R
+                      tests/R/fib.R
+                      tests/R/fib-benchmark.R
+                      R/collectAntis.R
+extra-tmp-files:     inline-r.buildinfo
 
 source-repository head
-    type:     git
-    location: git://github.com/tweag/HaskellR.git
-    subdir:   inline-r
+  type:     git
+  location: git://github.com/tweag/HaskellR.git
+  subdir: inline-r
 
 library
-    exposed-modules:
-        Control.Memory.Region
-        Data.Vector.SEXP
-        Data.Vector.SEXP.Base
-        Data.Vector.SEXP.Mutable
-        Foreign.R
-        Foreign.R.Constraints
-        Foreign.R.Context
-        Foreign.R.Embedded
-        Foreign.R.Error
-        Foreign.R.Internal
-        Foreign.R.Parse
-        Foreign.R.Type
-        H.Prelude
-        H.Prelude.Interactive
-        Language.R
-        Language.R.Debug
-        Language.R.GC
-        Language.R.Globals
-        Language.R.HExp
-        Language.R.Instance
-        Language.R.Internal
-        Language.R.Internal.FunWrappers
-        Language.R.Internal.FunWrappers.TH
-        Language.R.Literal
-        Language.R.Matcher
-        Language.R.QQ
-
-    build-tools:      hsc2hs >=0
-    c-sources:        cbits/missing_r.c
-    hs-source-dirs:   src
-    other-modules:
-        Control.Monad.R.Class
-        Control.Monad.R.Internal
-        Data.Vector.SEXP.Mutable.Internal
-        Internal.Error
-
-    default-language: Haskell2010
-    other-extensions: CPP ForeignFunctionInterface
-    include-dirs:     cbits
-    includes:         cbits/missing_r.h
-    ghc-options:      -Wall -freduction-depth=32
+  exposed-modules:     Control.Memory.Region
+                       Data.Vector.SEXP
+                       Data.Vector.SEXP.Base
+                       Data.Vector.SEXP.Mutable
+                       Foreign.R
+                       Foreign.R.Constraints
+                       Foreign.R.Context
+                       Foreign.R.Embedded
+                       Foreign.R.Error
+                       Foreign.R.Internal
+                       Foreign.R.Parse
+                       Foreign.R.Type
+                       H.Prelude
+                       H.Prelude.Interactive
+                       Language.R
+                       Language.R.Debug
+                       Language.R.GC
+                       Language.R.Globals
+                       Language.R.HExp
+                       Language.R.Instance
+                       Language.R.Internal
+                       Language.R.Internal.FunWrappers
+                       Language.R.Internal.FunWrappers.TH
+                       Language.R.Literal
+                       Language.R.Matcher
+                       Language.R.QQ
+  if !os(windows)
+    exposed-modules:   Foreign.R.EventLoop
+                       Language.R.Event
+  other-modules:       Control.Monad.R.Class
+                       Control.Monad.R.Internal
+                       Data.Vector.SEXP.Mutable.Internal
+                       Internal.Error
+  build-depends:       base >=4.7 && <5
+                     , aeson >=0.6 && <2.2
+                     , bytestring >=0.10 && <0.12
+                     , containers >=0.5 && <0.7
+                     , data-default-class >=0.1.2.0 && <0.2
+                     , deepseq >=1.3 && <1.5
+                     , exceptions >=0.6 && <1.1
+                     , heredoc >=0.2 && <0.3
+                     , mtl >=2.1 && <2.3
+                     , pretty >=1.1 && <1.2
+                     , primitive >=0.5 && <0.8
+                     , process >=1.2 && <1.7
+                     , reflection >=2 && <2.2
+                     , setenv >=0.1.1 && <0.2
+                     , template-haskell >=2.8 && <2.20
+                     , temporary >=1.2 && <1.4
+                     , text >=0.11 && <2.1
+                     , th-lift >=0.6 && <0.9
+                     , th-orphans >=0.8 && <0.14
+                     , transformers >=0.3 && <0.6
+                     , vector >=0.10 && <0.14
+  if impl(ghc < 8.2.1)
     build-depends:
-        base >=4.7 && <5,
-        aeson >=0.6 && <2.2,
-        bytestring >=0.10 && <0.12,
-        containers >=0.5 && <0.7,
-        data-default-class >=0.1.2.0 && <0.2,
-        deepseq >=1.3 && <1.5,
-        exceptions >=0.6 && <1.1,
-        heredoc >=0.2 && <0.3,
-        inline-c >=0.6 && <0.10,
-        mtl >=2.1 && <2.3,
-        pretty >=1.1 && <1.2,
-        primitive >=0.5 && <0.8,
-        process >=1.2 && <1.7,
-        reflection >=2 && <2.2,
-        setenv >=0.1.1 && <0.2,
-        template-haskell >=2.8 && <2.20,
-        temporary >=1.2 && <1.4,
-        text >=0.11 && <2.1,
-        th-lift >=0.6 && <0.9,
-        th-orphans >=0.8 && <0.14,
-        transformers >=0.3 && <0.6,
-        vector >=0.10 && <0.14
-
-    if !os(windows)
-        exposed-modules:
-            Foreign.R.EventLoop
-            Language.R.Event
-
-    if impl(ghc <9)
-        build-depends: singletons >=2.7 && <3
-
-    else
-        build-depends:
-            singletons >=3 && <3.1,
-            singletons-th >=3 && <3.2
-
-    if os(windows)
-        extra-libraries: R
-
-    else
-        pkgconfig-depends: libR >=3.0
-        build-depends:     unix >=2.6 && <2.8
+      inline-c >=0.5.6.1 && <0.6
+  else
+    build-depends:
+      inline-c >=0.6 && <0.10
+  if impl(ghc <9)
+      build-depends: singletons >=2.7 && <3
+  else
+      build-depends:
+          singletons >=3 && <3.1,
+          singletons-th >=3 && <3.2
+  hs-source-dirs:      src
+  includes:            cbits/missing_r.h
+  c-sources:           cbits/missing_r.c
+  include-dirs:        cbits
+  default-language:    Haskell2010
+  other-extensions:    CPP
+                       ForeignFunctionInterface
+  build-tools:         hsc2hs
+  if os(windows)
+    extra-libraries:   R
+  else
+    build-depends:     unix >= 2.6 && <2.8
+    pkgconfig-depends: libR >= 3.0
+  -- XXX -fcontext-stack=32 required on GHC >= 7.8 to allow foreign
+  -- export function -wrappers of high arities.
+  ghc-options:         -Wall -freduction-depth=32
 
 test-suite tests
-    type:             exitcode-stdio-1.0
-    main-is:          tests.hs
-    hs-source-dirs:   tests
-    other-modules:
-        Test.GC
-        Test.FunPtr
-        Test.Constraints
-        Test.Event
-        Test.Regions
-        Test.Vector
-        Test.Matcher
-
-    default-language: Haskell2010
-    ghc-options:      -Wall -threaded
-    build-depends:
-        inline-r,
-        base >=4.6 && <5,
-        bytestring >=0.10 && <0.12,
-        directory >=1.2 && <1.4,
-        filepath >=1.3 && <1.5,
-        heredoc >=0.2 && <0.3,
-        ieee754 >=0.7 && <0.9,
-        mtl >=2.0 && <2.3,
-        process >=1.2 && <1.7,
-        quickcheck-assertions >=0.1.1 && <0.4,
-        singletons >=0.10 && <3.1,
-        strict >=0.3.2 && <0.5,
-        tasty >=0.11 && <1.5,
-        tasty-expected-failure >=0.11 && <0.13,
-        tasty-golden >=2.3 && <2.4,
-        tasty-hunit >=0.4.1 && <0.11,
-        tasty-quickcheck >=0.4.1 && <0.11,
-        temporary >=1.2 && <1.4,
-        text >=0.11 && <2.1,
-        vector >=0.12.3.1 && <0.14
-
-    if !os(windows)
-        build-depends: unix >=2.5 && <2.8
+  main-is:             tests.hs
+  type:                exitcode-stdio-1.0
+  build-depends:       inline-r
+                     , base >=4.6 && <5
+                     , bytestring >=0.10 && <0.12
+                     , directory >=1.2 && <1.4
+                     , filepath >=1.3 && <1.5
+                     , heredoc >=0.2 && <0.3
+                     , ieee754 >=0.7 && <0.9
+                     , mtl >=2.0 && <2.3
+                     , process >=1.2 && <1.7
+                     , quickcheck-assertions >=0.1.1 && <0.4
+                     , singletons >=0.10 && <3.1
+                     , strict >=0.3.2 && <0.5
+                     , tasty >=0.11 && <1.5
+                     , tasty-expected-failure >=0.11 && <0.13
+                     , tasty-golden >=2.3 && <2.4
+                     , tasty-hunit >=0.4.1 && <0.11
+                     , tasty-quickcheck >=0.4.1 && <0.11
+                     , temporary >=1.2 && <1.4
+                     , text >=0.11 && <2.1
+                     , vector >=0.12.3.1 && <0.14
+  if !os(windows)
+    build-depends:     unix >=2.5 && <2.8
+  other-modules:       Test.GC
+                       Test.FunPtr
+                       Test.Constraints
+                       Test.Event
+                       Test.Regions
+                       Test.Vector
+                       Test.Matcher
+  ghc-options:         -Wall -threaded
+  hs-source-dirs:      tests
+  default-language:    Haskell2010
 
 test-suite test-qq
-    type:             exitcode-stdio-1.0
-    main-is:          test-qq.hs
-    hs-source-dirs:   tests
-    default-language: Haskell2010
-    ghc-options:      -Wall -threaded
-    build-depends:
-        inline-r,
-        base >=4.6 && <5,
-        mtl >=2.0 && <2.3,
-        process >=1.2 && <1.7,
-        tasty-hunit >=0.4.1 && <0.11,
-        singletons >=0.9 && <3.1,
-        text >=0.11 && <2.1
+  main-is:             test-qq.hs
+  type:                exitcode-stdio-1.0
+  build-depends:       inline-r
+                     , base >=4.6 && <5
+                     , mtl >=2.0 && <2.3
+                     , process >=1.2 && <1.7
+                     , tasty-hunit >=0.4.1 && <0.11
+                     , singletons >=0.9 && <3.1
+                     , text >=0.11 && <2.1
+  ghc-options:         -Wall -threaded
+  hs-source-dirs:      tests
+  default-language:    Haskell2010
 
 test-suite test-shootout
-    type:             exitcode-stdio-1.0
-    main-is:          test-shootout.hs
-    hs-source-dirs:   tests
-    other-modules:    Test.Scripts
-    default-language: Haskell2010
-    ghc-options:      -Wall -threaded
-    build-depends:
-        inline-r,
-        base >=4.6 && <5,
-        filepath >=1.3 && <1.5,
-        process >=1.2 && <1.7,
-        silently >=1.2 && <1.3,
-        tasty >=0.3 && <1.5,
-        tasty-hunit >=0.4.1 && <0.11,
-        template-haskell >=2.8 && <2.20
-
-    if os(windows)
-        buildable: False
+  main-is:             test-shootout.hs
+  type:                exitcode-stdio-1.0
+  other-modules:       Test.Scripts
+  build-depends:       inline-r
+                     , base >=4.6 && <5
+                     , filepath >=1.3 && <1.5
+                     , process >=1.2 && <1.7
+                     , silently >=1.2 && <1.3
+                     , tasty >=0.3 && <1.5
+                     , tasty-hunit >=0.4.1 && <0.11
+                     , template-haskell >=2.8 && <2.20
+  ghc-options:         -Wall -threaded
+  hs-source-dirs:      tests
+  default-language:    Haskell2010
+  if os(windows)
+    buildable:         False
 
 benchmark bench-qq
-    type:             exitcode-stdio-1.0
-    main-is:          bench-qq.hs
-    hs-source-dirs:   tests
-    default-language: Haskell2010
-    ghc-options:      -Wall -threaded
-    build-depends:
-        inline-r,
-        base >=4.6 && <5,
-        criterion >=0.8 && <1.7,
-        filepath >=1.3 && <1.5,
-        process >=1.2 && <1.7,
-        template-haskell >=2.8 && <2.20
+  main-is:             bench-qq.hs
+  type:                exitcode-stdio-1.0
+  build-depends:       inline-r
+                     , base >=4.6 && <5
+                     , criterion >=0.8 && <1.7
+                     , filepath >=1.3 && <1.5
+                     , process >=1.2 && <1.7
+                     , template-haskell >=2.8 && <2.20
+  ghc-options:         -Wall -threaded
+  hs-source-dirs:      tests
+  default-language:    Haskell2010
 
 benchmark bench-hexp
-    type:             exitcode-stdio-1.0
-    main-is:          bench-hexp.hs
-    hs-source-dirs:   tests
-    default-language: Haskell2010
-    ghc-options:      -Wall -threaded
-    build-depends:
-        inline-r,
-        base >=4.6 && <5,
-        criterion >=0.8 && <1.7,
-        primitive >=0.5 && <0.8,
-        vector >=0.10 && <0.14,
-        singletons >=2.7 && <3.1
+  main-is:             bench-hexp.hs
+  type:                exitcode-stdio-1.0
+  build-depends:       inline-r
+                     , base >=4.6 && <5
+                     , criterion >=0.8 && <1.7
+                     , primitive >=0.5 && <0.8
+                     , vector >=0.10 && <0.14
+                     , singletons >=2.7 && <3.1
+  ghc-options:         -Wall -threaded
+  hs-source-dirs:      tests
+  default-language:    Haskell2010


### PR DESCRIPTION
This fixes up the build plan for GHCs 8.10, 9.0, and 9.2. GHC 9.4 would work for inline-r [1]  but it requires revisions in other packages.

Unfortunately my cabal tooling reformats everything but it looks like we haven't lost much.

[1] This  works
```
cabal build -w ghc-9.4 inline-r \
     --allow-newer=ihaskell-inline-r:template-haskell \
     --allow-newer=ihaskell:base \
     --allow-newer=ihaskell:ghc \
     --allow-newer=ghc-parser:ghc
```