### PR TITLE
Add missing collectAntis.R to extra-source-files

### DIFF
--- a/inline-r/inline-r.cabal
+++ b/inline-r/inline-r.cabal
@@ -34,6 +34,7 @@ extra-source-files:   CHANGELOG.md
                       tests/shootout/fannkuchredux.R
                       tests/R/fib.R
                       tests/R/fib-benchmark.R
+                      R/collectAntis.R
 extra-tmp-files:     inline-r.buildinfo
 
 source-repository head


### PR DESCRIPTION
Building this library by itself (locally by `cabal build` inside the repo) does not yield to issues,
but when building the library as a dependency (e.g. using cabal's `source-repository-package`) leads to this cabal error:

```
[31 of 34] Compiling Language.R.QQ    ( src/Language/R/QQ.hs, dist/build/Language/R/QQ.o, dist/build/Language/R/QQ.dyn_o )

src/Language/R/QQ.hs:138:9: error:
    • Exception when trying to run compile-time code:
        R/collectAntis.R: openFile: does not exist (No such file or directory)
      Code: quoteExp Heredoc.there "R/collectAntis.R"
    • In the quasi-quotation: [Heredoc.there|R/collectAntis.R|]
    |
138 |         [Heredoc.there|R/collectAntis.R|]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

This patch fixes it by adding a missing R file in `extra-source-files`. Credits goes to @michaelpj for finding the problem out.