### PR TITLE
Foreign.R and assorted modules cleanup

### DIFF
--- a/inline-r/inline-r.cabal
+++ b/inline-r/inline-r.cabal
@@ -125,7 +125,10 @@ library
     pkgconfig-depends: libR >= 3.0
   -- XXX -fcontext-stack=32 required on GHC >= 7.8 to allow foreign
   -- export function -wrappers of high arities.
-  ghc-options:         -Wall -freduction-depth=32
+  ghc-options:         -freduction-depth=32
+  --- We don't use ticks for promoted constructors, because we use
+  --- promoted constructors heavily and because they confuse hsc2hs.
+  ghc-options:         -Wall -fno-warn-unticked-promoted-constructors
 
 test-suite tests
   main-is:             tests.hs

--- a/inline-r/inline-r.cabal
+++ b/inline-r/inline-r.cabal
@@ -51,6 +51,7 @@ library
                        Foreign.R.Constraints
                        Foreign.R.Context
                        Foreign.R.Embedded
+                       Foreign.R.Encoding
                        Foreign.R.Error
                        Foreign.R.Internal
                        Foreign.R.Parse

--- a/inline-r/inline-r.cabal
+++ b/inline-r/inline-r.cabal
@@ -77,7 +77,7 @@ library
                        Control.Monad.R.Internal
                        Data.Vector.SEXP.Mutable.Internal
                        Internal.Error
-  build-depends:       base >= 4.7 && < 5
+  build-depends:       base >= 4.11 && < 5
                      , aeson >= 0.6
                      , bytestring >= 0.10
                      , containers >= 0.5

--- a/inline-r/src/Data/Vector/SEXP.hs
+++ b/inline-r/src/Data/Vector/SEXP.hs
@@ -301,9 +301,7 @@ import Foreign.Marshal.Array ( copyArray )
 import qualified GHC.Foreign as GHC
 import qualified GHC.ForeignPtr as GHC
 import GHC.IO.Encoding.UTF8
-#if __GLASGOW_HASKELL__ >= 708
 import qualified GHC.Exts as Exts
-#endif
 import System.IO.Unsafe
 
 import Prelude
@@ -403,13 +401,11 @@ instance (Reifies t (AcquireIO s), SVECTOR ty a) => G.Vector (W t ty) a where
   {-# INLINE elemseq #-}
   elemseq _ = seq
 
-#if __GLASGOW_HASKELL__ >= 708
 instance SVECTOR ty a => Exts.IsList (Vector ty a) where
   type Item (Vector ty a) = a
   fromList = fromList
   fromListN = fromListN
   toList = toList
-#endif
 
 -- | Return Pointer of the first element of the vector storage.
 unsafeToPtr :: Storable a => Vector ty a -> Ptr a

--- a/inline-r/src/Foreign/R.hs
+++ b/inline-r/src/Foreign/R.hs
@@ -15,7 +15,6 @@
 --
 -- This module is intended to be imported qualified.
 
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveDataTypeable #-}

--- a/inline-r/src/Foreign/R.hs
+++ b/inline-r/src/Foreign/R.hs
@@ -169,10 +169,9 @@ import Data.Typeable (Typeable)
 import Foreign (Ptr, castPtr)
 import Foreign.C
 import Foreign.R.Context (rCtx, SEXP0(..), SEXPREC)
+import Foreign.R.Encoding
 import qualified Language.C.Inline as C
 import Prelude hiding (asTypeOf, length)
-
-#include <Rinternals.h>
 
 C.context (C.baseCtx <> rCtx)
 C.include "<Rinternals.h>"
@@ -477,36 +476,6 @@ findVar (unsexp -> a) (unsexp -> env) = sexp <$>
 mkWeakRef :: SEXP s a -> SEXP s b -> SEXP s c -> Bool -> IO (SEXP V 'R.WeakRef)
 mkWeakRef (unsexp -> a) (unsexp -> b) (unsexp -> c) (cIntFromEnum -> t) = sexp <$>
   [C.exp| SEXP {R_MakeWeakRef($(SEXP a), $(SEXP b), $(SEXP c), $(int t))}|]
-
--------------------------------------------------------------------------------
--- Encoding                                                                  --
--------------------------------------------------------------------------------
-
--- | Content encoding.
-data CEType
-  = CE_Native
-  | CE_UTF8
-  | CE_Latin1
-  | CE_Bytes
-  | CE_Symbol
-  | CE_Any
-  deriving (Eq, Show)
-
-instance Enum CEType where
-  fromEnum CE_Native = #const CE_NATIVE
-  fromEnum CE_UTF8   = #const CE_UTF8
-  fromEnum CE_Latin1 = #const CE_LATIN1
-  fromEnum CE_Bytes  = #const CE_BYTES
-  fromEnum CE_Symbol = #const CE_SYMBOL
-  fromEnum CE_Any    = #const CE_ANY
-  toEnum i = case i of
-    (#const CE_NATIVE) -> CE_Native
-    (#const CE_UTF8)   -> CE_UTF8
-    (#const CE_LATIN1) -> CE_Latin1
-    (#const CE_BYTES)  -> CE_Bytes
-    (#const CE_SYMBOL) -> CE_Symbol
-    (#const CE_ANY)    -> CE_Any
-    _ -> error "CEType.fromEnum: unknown tag"
 
 -- | Perform an action with resource while protecting it from the garbage
 -- collection. This function is a safer alternative to 'R.protect' and

--- a/inline-r/src/Foreign/R.hs
+++ b/inline-r/src/Foreign/R.hs
@@ -18,9 +18,7 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DataKinds #-}
-#if __GLASGOW_HASKELL__ < 710
 {-# LANGUAGE DeriveDataTypeable #-}
-#endif
 {-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE ForeignFunctionInterface #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
@@ -152,9 +150,6 @@ module Foreign.R
   ) where
 
 import Control.Memory.Region
-#if __GLASGOW_HASKELL__ < 804
-import Data.Monoid ((<>))
-#endif
 import Foreign.R.Internal
 import Foreign.R.Type
 import Foreign.R.Type as R
@@ -163,9 +158,6 @@ import Control.Applicative
 import Control.Exception (bracket)
 import Data.Complex
 import Data.Int (Int32)
-#if __GLASGOW_HASKELL__ < 710
-import Data.Typeable (Typeable)
-#endif
 import Foreign (Ptr, castPtr)
 import Foreign.C
 import Foreign.R.Context (rCtx, SEXP0(..), SEXPREC)

--- a/inline-r/src/Foreign/R/Context.hsc
+++ b/inline-r/src/Foreign/R/Context.hsc
@@ -31,9 +31,6 @@ newtype {-# CTYPE "SEXP" #-} SEXP0 = SEXP0 { unSEXP0 :: Ptr SEXPREC }
   deriving ( Eq
            , Ord
            , Storable
-#if __GLASGOW_HASKELL__ < 710
-           , Typeable
-#endif
            )
 
 instance Show SEXP0 where

--- a/inline-r/src/Foreign/R/Encoding.hsc
+++ b/inline-r/src/Foreign/R/Encoding.hsc
@@ -1,0 +1,31 @@
+-- | Character encodings.
+
+#include <Rinternals.h>
+
+module Foreign.R.Encoding where
+
+-- | Content encoding.
+data CEType
+  = CE_Native
+  | CE_UTF8
+  | CE_Latin1
+  | CE_Bytes
+  | CE_Symbol
+  | CE_Any
+  deriving (Eq, Show)
+
+instance Enum CEType where
+  fromEnum CE_Native = #const CE_NATIVE
+  fromEnum CE_UTF8   = #const CE_UTF8
+  fromEnum CE_Latin1 = #const CE_LATIN1
+  fromEnum CE_Bytes  = #const CE_BYTES
+  fromEnum CE_Symbol = #const CE_SYMBOL
+  fromEnum CE_Any    = #const CE_ANY
+  toEnum i = case i of
+    (#const CE_NATIVE) -> CE_Native
+    (#const CE_UTF8)   -> CE_UTF8
+    (#const CE_LATIN1) -> CE_Latin1
+    (#const CE_BYTES)  -> CE_Bytes
+    (#const CE_SYMBOL) -> CE_Symbol
+    (#const CE_ANY)    -> CE_Any
+    _ -> error "CEType.fromEnum: unknown tag"

--- a/inline-r/src/Foreign/R/Internal.hs
+++ b/inline-r/src/Foreign/R/Internal.hs
@@ -7,9 +7,6 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DataKinds #-}
-#if __GLASGOW_HASKELL__ < 710
-{-# LANGUAGE DeriveDataTypeable #-}
-#endif
 {-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE ForeignFunctionInterface #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
@@ -28,9 +25,6 @@ import Control.Applicative
 import Control.DeepSeq (NFData(..))
 import Control.Monad.Primitive ( unsafeInlineIO )
 import Data.Singletons (fromSing)
-#if __GLASGOW_HASKELL__ < 710
-import Data.Typeable (Typeable)
-#endif
 import Foreign (Ptr, castPtr, Storable(..))
 import Foreign.C
 import Prelude hiding (asTypeOf, length)
@@ -46,9 +40,6 @@ newtype SEXP s (a :: SEXPTYPE) = SEXP { unSEXP :: SEXP0 }
   deriving ( Eq
            , Ord
            , Storable
-#if __GLASGOW_HASKELL__ < 710
-           , Typeable
-#endif
            )
 
 instance Show (SEXP s a) where

--- a/inline-r/src/Foreign/R/Internal.hs
+++ b/inline-r/src/Foreign/R/Internal.hs
@@ -4,7 +4,6 @@
 -- Low-level bindings to core R datatypes and functions which depend on
 -- computing offsets of C struct field. We use hsc2hs for this purpose.
 
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE ExistentialQuantification #-}

--- a/inline-r/src/Foreign/R/Internal.hs
+++ b/inline-r/src/Foreign/R/Internal.hs
@@ -17,10 +17,6 @@
 {-# LANGUAGE ViewPatterns #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
-#if __GLASGOW_HASKELL__ >= 710
--- We don't use ticks in this module, because they confuse hsc2hs.
-{-# OPTIONS_GHC -fno-warn-unticked-promoted-constructors #-}
-#endif
 module Foreign.R.Internal where
 
 import Control.Memory.Region

--- a/inline-r/src/Foreign/R/Parse.hsc
+++ b/inline-r/src/Foreign/R/Parse.hsc
@@ -9,9 +9,6 @@
 {-# LANGUAGE ViewPatterns #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE ForeignFunctionInterface #-}
-#if __GLASGOW_HASKELL__ >= 710
-{-# OPTIONS_GHC -fno-warn-unticked-promoted-constructors #-}
-#endif
 
 #include <Rinternals.h>
 #include <R_ext/Parse.h>

--- a/inline-r/src/Foreign/R/Type.hsc
+++ b/inline-r/src/Foreign/R/Type.hsc
@@ -11,9 +11,6 @@
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
 
-#if __GLASGOW_HASKELL__ >= 710
-{-# OPTIONS_GHC -fno-warn-unticked-promoted-constructors #-}
-#endif
 {-# OPTIONS_GHC -fno-warn-unused-binds #-}
 
 -- |

--- a/inline-r/src/Language/R/HExp.hs
+++ b/inline-r/src/Language/R/HExp.hs
@@ -26,7 +26,6 @@
 -- 'HExp' is the /view/ and 'hexp' is the /view function/ that projects 'SEXP's
 -- into 'HExp' views.
 
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE GADTs #-}

--- a/inline-r/src/Language/R/HExp.hs
+++ b/inline-r/src/Language/R/HExp.hs
@@ -33,9 +33,7 @@
 {-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE PolyKinds #-}
-#if __GLASGOW_HASKELL__ >= 708
 {-# LANGUAGE RoleAnnotations #-}
-#endif
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE ViewPatterns #-}


### PR DESCRIPTION
- Move character encoding stuff to own module
- Set -Wno-warn-unticked-promoted-constructors globally
- Remove CPP to support old versions of GHC
- Bump lower bound of base to 4.11.
- Remove unneeded CPP language pragmas
