### PR TITLE
Add R_LIBS_SITE to populateEnv

### DIFF
--- a/inline-r/src/Language/R/Instance.hs
+++ b/inline-r/src/Language/R/Instance.hs
@@ -196,6 +196,10 @@ populateEnv = do
     when (mh == Nothing) $
       setEnv "R_HOME" =<< fmap (head . lines) (readProcess "R" ["-e","cat(R.home())","--quiet","--slave"] "")
 
+    ml <- lookupEnv "R_LIBS_SITE"
+    when (ml == Nothing) $
+      setEnv "R_LIBS_SITE" =<< fmap (head .  lines) (readProcess "R" ["-e","cat(.libPaths(),sep=\":\")","--quiet","--slave"] "")
+
 -- | A static address that survives GHCi reloadings which indicates
 -- whether R has been initialized.
 foreign import ccall "missing_r.h &isRInitialized" isRInitializedPtr :: Ptr CInt


### PR DESCRIPTION
This change helped us with our Nix infrastructure, to propagate the nix-installed R libraries to the underlying R process.
Is this something worth considering for inclusion in upstream?