### PR TITLE
Populate R_LIBS environment variable

### DIFF
--- a/inline-r/src/Language/R/Instance.hs
+++ b/inline-r/src/Language/R/Instance.hs
@@ -196,6 +196,10 @@ populateEnv = do
     when (mh == Nothing) $
       setEnv "R_HOME" =<< fmap (head . lines) (readProcess "R" ["-e","cat(R.home())","--quiet","--slave"] "")
 
+    ml <- lookupEnv "R_LIBS"
+    when (ml == Nothing) $
+      setEnv "R_LIBS" =<< fmap (head .  lines) (readProcess "R" ["-e","cat(.libPaths(),sep=if (.Platform$OS.type == \"unix\") \":\" else \";\")","--quiet","--slave"] "")
+
 -- | A static address that survives GHCi reloadings which indicates
 -- whether R has been initialized.
 foreign import ccall "missing_r.h &isRInitialized" isRInitializedPtr :: Ptr CInt


### PR DESCRIPTION
This patch allowed the underlying R process see our Nix-installed R libraries.
Is this perhaps something worth to upstream?

Note: this patch has only been tested on Linux and Wine (not yet on macosx or native windows). @michaelpj @zeme-iohk