### PR TITLE
Map backslashes to forwardslashes in temp file names under Windows

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -1,5 +1,7 @@
 name: Continuous integration
-on: [push]
+on:
+  - push
+  - pull_request
 
 jobs:
   build:

--- a/inline-r/inline-r.cabal
+++ b/inline-r/inline-r.cabal
@@ -199,6 +199,30 @@ test-suite test-shootout
   if os(windows)
     buildable: False
 
+test-suite test-env1
+  main-is: test-env1.hs
+  type: exitcode-stdio-1.0
+  build-depends:
+    inline-r,
+    base >=4.6 && <5,
+    tasty >=0.3 && <1.5,
+    tasty-hunit >=0.4.1 && <0.11,
+  ghc-options: -Wall -threaded
+  hs-source-dirs: tests
+  default-language: Haskell2010
+
+test-suite test-env2
+  main-is: test-env2.hs
+  type: exitcode-stdio-1.0
+  build-depends:
+    inline-r,
+    base >=4.6 && <5,
+    tasty >=0.3 && <1.5,
+    tasty-hunit >=0.4.1 && <0.11,
+  ghc-options: -Wall -threaded
+  hs-source-dirs: tests
+  default-language: Haskell2010
+
 benchmark bench-qq
   main-is: bench-qq.hs
   type: exitcode-stdio-1.0

--- a/inline-r/src/Language/R/QQ.hs
+++ b/inline-r/src/Language/R/QQ.hs
@@ -110,12 +110,14 @@ chop :: String -> String
 chop name = take (length name - length antiSuffix) name
 
 -- | Map backwards slashes to forward slashes.
+#ifdef mingw32_HOST_OS
 fixwinslash :: String -> String
 fixwinslash str = let
   repl '\\' = '/'
   repl c = c
   in map repl str
-     
+#endif
+
 -- | Find all occurences of antiquotations.
 --
 -- This function works by parsing the user's R code in a separate
@@ -148,7 +150,11 @@ collectAntis input = do
       -- Unix systems (and R) are less tolerant of naked backslashes 
       -- outside of valid escape sequences. For example, 
       -- str <- "C:\Users\joe" is invalid in R.
-      fixwinslash  $ "input_file <- \"" ++ input_file ++ "\"\n" ++
+#ifdef mingw32_HOST_OS
+      $ "input_file <- \"" ++ (fixwinslash input_file) ++ "\"\n" ++
+#else
+      $ "input_file <- \"" ++ input_file ++ "\"\n" ++
+#endif
         [Heredoc.there|R/collectAntis.R|]
     return $ case code of
       ExitSuccess -> Right $ words stdout

--- a/inline-r/src/Language/R/QQ.hs
+++ b/inline-r/src/Language/R/QQ.hs
@@ -54,7 +54,6 @@ import qualified System.IO.Temp as Temp
 import System.Process
 import System.IO
 import System.Exit
-import Debug.Trace
 
 -------------------------------------------------------------------------------
 -- Compile time Quasi-Quoter                                                 --
@@ -140,7 +139,7 @@ collectAntis input = do
   Temp.withSystemTempFile "inline-r-.R" $ \input_file input_fh -> do
     hPutStr input_fh input
     hClose input_fh
-    (code, stdout, stderr) <- readProcessWithExitCode "R" ["--slave"] $
+    (code, stdout, stderr) <- readProcessWithExitCode "R" ["--slave"]
       -- Note: --slave was recently renamed to --no-echo. --slave still works
       -- but is no longer documented. Using the old option name for now just
       -- in case the user have an older (pre-2020) version of R.

--- a/inline-r/tests/test-env1.hs
+++ b/inline-r/tests/test-env1.hs
@@ -1,0 +1,17 @@
+module Main where
+
+import qualified Language.R.Instance as R
+
+import System.Environment
+import Test.Tasty
+import Test.Tasty.HUnit
+
+tests :: TestTree
+tests = testCase "initialize respects R_LIBS env" $ do
+            let somePath = "bogusfasdfassomePath"
+            setEnv "R_LIBS" somePath
+            _ <- R.initialize R.defaultConfig
+            (somePath @=?) =<< getEnv "R_LIBS"
+
+main :: IO ()
+main = defaultMain tests

--- a/inline-r/tests/test-env2.hs
+++ b/inline-r/tests/test-env2.hs
@@ -1,0 +1,20 @@
+{-# LANGUAGE QuasiQuotes #-}
+module Main where
+
+import H.Prelude as H
+import qualified Language.R.Instance as R
+
+import System.Environment.Blank as BlankEnv
+import Test.Tasty
+import Test.Tasty.HUnit
+
+tests :: TestTree
+tests = testCase "blank R_LIBS does not affect R's stdlib" $ do
+            -- use an explcitly blank env R_LIBS="", see `System.Environment.setEnv`
+            BlankEnv.setEnv "R_LIBS" "" True
+            _ <- R.initialize R.defaultConfig
+            ("TRUE" @=?) =<< runRegion
+                (fromSomeSEXP <$> [r| deparse(.libPaths() == normalizePath(.Library,winslash="/")) |] :: R s String)
+
+main :: IO ()
+main = defaultMain tests


### PR DESCRIPTION
Fixes problem under Windows where R rejects paths of the form "C:\Users\joe"
because of naked backslashes.