### PR TITLE
Import from Control.Monad directly

### DIFF
--- a/inline-r/src/Language/R/Instance.hs
+++ b/inline-r/src/Language/R/Instance.hs
@@ -37,6 +37,7 @@ module Language.R.Instance
   , finalize
   ) where
 
+import           Control.Monad ((<=<), unless, when, zipWithM_)
 import           Control.Monad.Primitive (PrimMonad(..))
 import           Control.Monad.R.Class
 import           Control.Monad.ST.Unsafe (unsafeSTToIO)


### PR DESCRIPTION
This enables compatibility with the mtl-2.3 series which removed some
reexports.

Fixes #411.
